### PR TITLE
Add npm scripts, express, live-reload, & index.js

### DIFF
--- a/extensionDirectory/popup.html
+++ b/extensionDirectory/popup.html
@@ -27,7 +27,7 @@
         <div id=ls></div>
 
     </div>
-    <iframe src="http://boundless-edge.surge.sh/" height="200px" width="200px" id="iframe"></iframe>
+    <iframe src="http://localhost:3000/iframe" height="200px" width="200px" id="iframe"></iframe>
     <script id='script' src="popup.js"></script>
 </body>
 

--- a/formMenu/index.html
+++ b/formMenu/index.html
@@ -6,10 +6,11 @@
   </head>
   <body>
     <div>
-      <p>form goes here!</p>
+      <p>form</p>
       <div id="destination"></div>
     </div>
   </body>
-    <iframe src="http://boundless-edge.surge.sh/" height="200px" width="200px" id="iframe"></iframe>
-  <script src="formPage.js"></script>
+    <iframe src="http://localhost:3000/iframe" height="200px" width="200px" id="iframe"></iframe>
+    <script src="formPage.js"></script>
+    <script src="http://localhost:9090"></script>
 </html>

--- a/iframe/CNAME
+++ b/iframe/CNAME
@@ -1,1 +1,0 @@
-boundless-edge.surge.sh

--- a/iframe/index.html
+++ b/iframe/index.html
@@ -6,9 +6,10 @@
   </head>
   <body>
     <div>
-      <p>Hello world two!</p>
+      <p>iframe</p>
       <div id="results"></div>
     </div>
   </body>
   <script src="iframe.js"></script>
+    <script src="http://localhost:9090"></script>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+
+app.use('/', express.static(path.resolve(__dirname, 'formMenu/')));
+
+app.use('/iframe', express.static(path.resolve(__dirname, 'iframe/')));
+
+app.listen(3000);
+
+console.log('ExpungeVT form served at localhost:3000 \n ...iframe served at localhost:3000/iframe (for now)');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,756 @@
+{
+  "name": "expunge-vt",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "Base64": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.1.4.tgz",
+      "integrity": "sha1-6fbGvvVn/WNepBYqsU3TKedKpt4=",
+      "dev": true
+    },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "dev": true,
+      "requires": {
+        "mime-types": "2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
+    "backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha1-AJgveBWOxtA/mWk+wPtfeyrR4o4=",
+      "dev": true
+    },
+    "bal-util": {
+      "version": "1.13.13",
+      "resolved": "https://registry.npmjs.org/bal-util/-/bal-util-1.13.13.tgz",
+      "integrity": "sha1-YyxJUgo2fsWqhUaI4Qgn2bUZMl8=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
+      "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q=",
+      "dev": true
+    },
+    "body-parser": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "on-finished": "2.3.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "1.6.18"
+      }
+    },
+    "bops": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
+      "integrity": "sha1-CC0dVfoB5g29wuvC26N/ZZVUzzo=",
+      "dev": true,
+      "requires": {
+        "base64-js": "0.0.2",
+        "to-utf8": "0.0.1"
+      }
+    },
+    "browserify": {
+      "version": "1.16.8",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-1.16.8.tgz",
+      "integrity": "sha1-0zeIztuyZh6y73ePXiDe1p1FHwE=",
+      "dev": true,
+      "requires": {
+        "buffer-browserify": "0.0.5",
+        "coffee-script": "1.12.7",
+        "commondir": "0.0.2",
+        "crypto-browserify": "0.4.0",
+        "deputy": "0.0.4",
+        "detective": "0.2.1",
+        "http-browserify": "0.1.14",
+        "nub": "0.0.0",
+        "optimist": "0.3.7",
+        "resolve": "0.2.8",
+        "syntax-error": "0.0.1",
+        "vm-browserify": "0.0.4"
+      }
+    },
+    "browserify-server": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-server/-/browserify-server-2.0.4.tgz",
+      "integrity": "sha1-tkpfTquQv3ZBj5SSZk20H5xPeoY=",
+      "dev": true,
+      "requires": {
+        "browserify": "1.16.8",
+        "ecstatic": "0.1.7",
+        "filed": "0.0.7",
+        "optimist": "0.3.7"
+      }
+    },
+    "buffer-browserify": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/buffer-browserify/-/buffer-browserify-0.0.5.tgz",
+      "integrity": "sha1-iqaGMciogpxqTufvmjrH8sMemD4=",
+      "dev": true,
+      "requires": {
+        "base64-js": "0.0.2"
+      }
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "dev": true
+    },
+    "commondir": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.2.tgz",
+      "integrity": "sha1-xJyIgMb+loRLs1Jd0ucxQFDDie4=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.0.1.tgz",
+      "integrity": "sha1-AYsYvBx9BzotyCqkhEI0GixN158=",
+      "dev": true,
+      "requires": {
+        "bops": "0.0.6"
+      }
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "crypto-browserify": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.4.0.tgz",
+      "integrity": "sha1-JG9qM3uITJn/6L+whaGEruYMM/M=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "deputy": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/deputy/-/deputy-0.0.4.tgz",
+      "integrity": "sha1-7cAKnvXFNSfEBTKFNMmXla2kHL8=",
+      "dev": true,
+      "requires": {
+        "detective": "0.2.1",
+        "mkdirp": "0.3.5"
+      }
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detective": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-0.2.1.tgz",
+      "integrity": "sha1-nOkmAf0iOBDClDKtA0+MYti4ZU8=",
+      "dev": true,
+      "requires": {
+        "esprima": "0.9.9"
+      }
+    },
+    "ecstatic": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-0.1.7.tgz",
+      "integrity": "sha1-siEFaHicAp9hDqTgA5W7r2IgEDQ=",
+      "dev": true,
+      "requires": {
+        "ent": "0.0.7",
+        "mime": "1.2.5"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.5.tgz",
+          "integrity": "sha1-nu0HMCKov14WyFZsaGe4gyv7+hM=",
+          "dev": true
+        }
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
+    },
+    "ent": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-0.0.7.tgz",
+      "integrity": "sha1-g11Of556jUkhxpLpAQ7JdtpemUk=",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-0.9.9.tgz",
+      "integrity": "sha1-G5CSXJddYy1ygpOcO7nDpCPDBJA=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
+    "express": {
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.3",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "2.0.5",
+        "qs": "6.5.2",
+        "range-parser": "1.2.0",
+        "safe-buffer": "5.1.2",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.4.0",
+        "type-is": "1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
+      }
+    },
+    "faye-websocket": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
+      "integrity": "sha1-wUxbO/FNdBf/v9mQwKdJXNnzN7w=",
+      "dev": true
+    },
+    "filed": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/filed/-/filed-0.0.7.tgz",
+      "integrity": "sha1-MIfsUx+5p4YApuyOCxBuLFdNl3M=",
+      "dev": true
+    },
+    "finalhandler": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.3",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "h": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/h/-/h-0.1.0.tgz",
+      "integrity": "sha1-JCEf4dnO8rNsro/4JVYG6hLs37U=",
+      "dev": true
+    },
+    "hound": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/hound/-/hound-1.0.5.tgz",
+      "integrity": "sha1-WbvTkiDrSlQd/04t40HW2vb4ook=",
+      "dev": true
+    },
+    "http-browserify": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-0.1.14.tgz",
+      "integrity": "sha1-nIs/lAAiBFR8fL5Saa/i6mL3HH8=",
+      "dev": true,
+      "requires": {
+        "Base64": "0.1.4",
+        "concat-stream": "1.0.1"
+      }
+    },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dev": true,
+      "requires": {
+        "depd": "1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.4.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+      "dev": true
+    },
+    "live-reload": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/live-reload/-/live-reload-1.1.0.tgz",
+      "integrity": "sha1-KqF+mKF9nHncreYywUad8ZJV/WA=",
+      "dev": true,
+      "requires": {
+        "browserify-server": "2.0.4",
+        "filed": "0.0.7",
+        "hound": "1.0.5",
+        "optimist": "0.3.7",
+        "reconnect": "0.1.5",
+        "shoe": "0.0.5",
+        "watchr": "2.1.6"
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.40.0"
+      }
+    },
+    "mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "dev": true
+    },
+    "node-uuid": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.3.3.tgz",
+      "integrity": "sha1-09tNe1aBDZ5AMjQnZigq8HORcps=",
+      "dev": true
+    },
+    "nub": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/nub/-/nub-0.0.0.tgz",
+      "integrity": "sha1-s2m9Mr3eZq9ZYFw7BSC8IZ3MwE8=",
+      "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "optimist": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+      "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+      "dev": true,
+      "requires": {
+        "wordwrap": "0.0.3"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
+    },
+    "proxy-addr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+      "dev": true,
+      "requires": {
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.9.0"
+      }
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
+      }
+    },
+    "reconnect": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/reconnect/-/reconnect-0.1.5.tgz",
+      "integrity": "sha1-3/6iUtYb6/swLsFwzvc9LS52WPI=",
+      "dev": true,
+      "requires": {
+        "backoff": "1.0.0",
+        "h": "0.1.0",
+        "shoe": "0.0.15"
+      },
+      "dependencies": {
+        "shoe": {
+          "version": "0.0.15",
+          "resolved": "https://registry.npmjs.org/shoe/-/shoe-0.0.15.tgz",
+          "integrity": "sha1-uu2PGn8I9TC2bwkUKH/KplsSRDo=",
+          "dev": true,
+          "requires": {
+            "sockjs": "0.3.7",
+            "sockjs-client": "0.0.0-unreleasable"
+          },
+          "dependencies": {
+            "sockjs-client": {
+              "version": "0.0.0-unreleasable",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "resolve": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.2.8.tgz",
+      "integrity": "sha1-/bF9SrsOyvb4DWesA88pAIj2wNA=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.3",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.3",
+        "send": "0.16.2"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
+    },
+    "shoe": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/shoe/-/shoe-0.0.5.tgz",
+      "integrity": "sha1-e0LcIKymMWasV/FIUtSVoczT+7M=",
+      "dev": true,
+      "requires": {
+        "sockjs-client": "git://github.com/substack/sockjs-client.git#40d48d06b4dba884416bf88a051f76ca3c8ffcae",
+        "sockjs-windows": "0.3.1"
+      }
+    },
+    "sockjs": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.7.tgz",
+      "integrity": "sha1-KVDgWG2KnTBElYqDGt5o2xl3Scs=",
+      "dev": true,
+      "requires": {
+        "faye-websocket": "0.4.4",
+        "node-uuid": "1.3.3"
+      }
+    },
+    "sockjs-client": {
+      "version": "git://github.com/substack/sockjs-client.git#40d48d06b4dba884416bf88a051f76ca3c8ffcae",
+      "dev": true
+    },
+    "sockjs-windows": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/sockjs-windows/-/sockjs-windows-0.3.1.tgz",
+      "integrity": "sha1-mYWk5DV5HXaUCCmZVL2W3lacj/Y=",
+      "dev": true,
+      "requires": {
+        "faye-websocket": "0.4.0",
+        "node-uuid": "1.3.3"
+      },
+      "dependencies": {
+        "faye-websocket": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.0.tgz",
+          "integrity": "sha1-6aj8az5aYQ8zCOi5eCh2oBp0V5k=",
+          "dev": true
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+      "dev": true
+    },
+    "syntax-error": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-0.0.1.tgz",
+      "integrity": "sha1-AZ0HU0jNjFt58GA8c+U4kafFI10=",
+      "dev": true,
+      "requires": {
+        "esprima": "0.9.9"
+      }
+    },
+    "to-utf8": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+      "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI=",
+      "dev": true
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.24"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
+    "vm-browserify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+      "dev": true,
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
+    "watchr": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/watchr/-/watchr-2.1.6.tgz",
+      "integrity": "sha1-bciVv2yVq29eBtgRlIsyCphBOJE=",
+      "dev": true,
+      "requires": {
+        "bal-util": "1.13.13"
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "expunge-vt",
+  "version": "1.0.0",
+  "description": "This project attempts to help Vermont Legal Aid clear records more quickly during their expungment clinics.",
+  "main": "index.js",
+  "scripts": {
+    "start": "npm run livereload & node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "livereload": "live-reload formMenu/ iframe/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/codeforbtv/expunge-vt.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/codeforbtv/expunge-vt/issues"
+  },
+  "homepage": "https://github.com/codeforbtv/expunge-vt#readme",
+  "devDependencies": {
+    "express": "^4.16.4",
+    "live-reload": "^1.1.0"
+  }
+}


### PR DESCRIPTION
I went with npm scripts instead of Gulp or Grunt as the task runner, seems to have enough functionality for us to get started developing. If we want to add support for sass/less we'll have to add a `dist/` folder and change how the livereloading is wired up.

Don't forget to run `npm install`! 

You can start developing with live reloading on both the iframe and the form using `npm start`

:beers: :exclamation: 