### PR TITLE
Handling many docket numbers

### DIFF
--- a/extensionDirectory/filings.css
+++ b/extensionDirectory/filings.css
@@ -72,13 +72,14 @@
 
 .filing-nav {
     position: fixed;
-    top:100px;
+    top:60px;
+    height: calc(100vh - 60px);
     left:0;
     padding:1rem;
-    padding-left:1;
     z-index: 100;
     background-color:#fff;
     width:15em;
+    overflow-y:scroll;
 }
 .filing-nav ol {
     padding:0;
@@ -288,7 +289,10 @@ p.document-meta-data__body {
 .stipulated-closing {
     margin-top:1.5rem;
 }
-
+p.filing-dated-city {
+    margin-top:1.5rem;
+    margin-bottom:1.5rem;
+}
 /* Use this with a span full of non-breaking spaces to give it a solid fill-in underline */
 .fill-in {
     opacity: 1;
@@ -311,7 +315,7 @@ p.document-meta-data__body {
         padding: 6rem;
         height: 100%;
         border:2px solid #ddd;
-        margin-left:15rem;
+        margin-left:17rem;
         margin-right:auto;
         margin-top:8rem;
         position: relative;

--- a/extensionDirectory/filings.html
+++ b/extensionDirectory/filings.html
@@ -239,8 +239,8 @@
 
 
                                         <template v-else>
-                                            <filing-dated-city></filing-dated-city>
                                             <div class="filing-closing">
+                                                <filing-dated-city></filing-dated-city>
                                                 <div class="filing-closing__signature-area filing-closing--align-right">
                                                     <div class="filing-closing__signature-box">
                                                         <p class="filing-closing__name">{{petitioner.name}}, Petitioner


### PR DESCRIPTION
Implements limiting Notice of Appearance to a max number of docketnums (Currently set at 10, adjust the variable at the top of filings.js to adjust.)
Also implements scrolling of the nav in cases where there are so many petitions that it runs off of the screen.