### PR TITLE
Indicates required fields and add a no-filing message

### DIFF
--- a/extensionDirectory/filings.html
+++ b/extensionDirectory/filings.html
@@ -32,7 +32,7 @@
 
 
     <div id="filing-app">
-        <template v-if="saved.counts.length > 0 && (filings || ineligible)">
+        <template v-if="numCountsToExpungeOrSeal > 0">
             <div v-if="petitioner.name" class="header-bar-wrapper no-print">
                 <div class="header-bar">
                     <h1>Filings for {{petitioner.name}}</h1>
@@ -596,8 +596,8 @@
         </template>
         <template v-else>
             <div class="no-filings">
-                <p>There are no filings to prepare. Please navigate to <a href="https://secure.vermont.gov/vtcdas/user">VT
-                    Courts Online</a> and open the Expunge VT extension to begin a new session.</p>
+                <p>There are no filings to prepare. <span v-if="numCountsNoAction > 0">Please open the ExpungeVT extension window and select a filing type for at least one of the loaded counts.</span><span v-else>Please navigate to <a href="https://secure.vermont.gov/vtcdas/user">VT
+                    Courts Online</a> and open the Expunge VT extension to begin a new session.</span></p>
             </div>
         </template>
         </div>

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -637,6 +637,12 @@ var app = new Vue({
       }
       return this.groupCountsIntoFilings(this.saved.counts, shouldGroupCounts) //counts, groupCountsFromMultipleDockets=true
     },
+    numCountsToExpungeOrSeal: function(){
+      return this.saved.counts.filter(count => count.filingType !== "").length
+    },
+    numCountsNoAction: function(){
+      return this.saved.counts.filter(count => count.filingType === "").length
+    },
     ineligible: function(){
       return this.groupIneligibleCounts(this.saved.counts);
     },

--- a/extensionDirectory/manage-counts.html
+++ b/extensionDirectory/manage-counts.html
@@ -56,11 +56,12 @@
                     <p><b>{{group.docketNum}} {{group.county | toCountyCode}}</b></p>
          
                     <div>
-                    <label style="min-width:70%;">Count Description<input class="form-control" v-model="group.description" placeholder="Description"></label></div>
+                        <form>
+                    <label style="min-width:70%;">Count Description<b>*</b><input required="" class="form-control" v-model="group.description" placeholder="Description"></label></div>
                     <div>
-                    <label><span>Docket Number</span><input class="form-control" v-model="group.docketNum" placeholder="Docket Num"></label>
-                    <label><span>County</span>
-                    <select class="form-control" v-model="group.county">
+                    <label><span>Docket Number<b>*</b></span><input required="" class="form-control" v-model="group.docketNum" placeholder="Docket Num"></label>
+                    <label><span>County<b>*</b></span>
+                    <select required="" class="form-control" v-model="group.county">
                         <option>Addison</option>
                         <option>Bennington</option>
                         <option>Caledonia</option>
@@ -76,31 +77,10 @@
                         <option>Windham</option>
                         <option>Windsor</option>
                     </select></label>
+                    <label><span>Disposition Date<b>*</b></span><input required="" class="form-control" type="date" v-model="group.dispositionDate" placeholder="Disposition Date"></label>
                     </div>
-                    <label><span>Original Docket Sheet Number</span><input class="form-control" v-model="group.docketSheetNum" placeholder="Docket Num"></label>
-
-                    <div><label><span>Alleged Offense Date</span><input class="form-control" type="date" v-model="group.allegedOffenseDate" placeholder="Offense Date"></label>
-                    <label><span>Arrest Citation Date</span><input class="form-control" type="date" v-model="group.arrestCitationDate" placeholder="Arrest Citation Date"></label>
-                    <label><span>Disposition Date</span><input class="form-control" type="date" v-model="group.dispositionDate" placeholder="Disposition Date"></label></div>
-                    <div>
-                    <label width="400px">Offense Disposition<input class="form-control" v-model="group.offenseDisposition" placeholder="e.g. Dismissed By State"></label>
-                  
-                    <label class="checkbox-inline"><input v-model="group.isDismissed" type="checkbox"><span> Is Dismissed</span></label>
-                    </div>
-                    
-                 
-                    <label for="vsc-title"><span>Statue Title</span><input id="vsc-title" class="form-control" v-model="group.titleNum" placeholder="Title"></label>
-                    <label for="vsc-section"><span>Statute Section</span><input id="vsc-section" class="form-control" v-model="group.sectionNum" placeholder="Section"></label>
-                    <label><span>Offense Class</span>
-                    <select class="form-control" v-model="group.offenseClass">
-                        <option value="mis">Misdemeanor</option>
-                        <option value="fel">Felony</option>
-                    </select>
-                  </label>
-                    <p v-if="group.titleNum || group.sectionNum || group.offenseClass"><b>{{group.titleNum || '-'}} V.S.A. &sect; {{group.sectionNum || '-'}} ({{group.offenseClass || '-'}})</b></b>
-                                 <div>
-                      <label>Filing for this count      
-                    <select class="form-control" v-model="group.filingType" class="petitionSelect selectpicker">
+                            <label>Filing for this count<b>*</b>     
+                    <select required="" class="form-control" v-model="group.filingType" class="petitionSelect selectpicker">
                                 <option value="">No Filing</option>
                                 <option value="X">Ineligible</option>
                                 <option value="ExC">Expunge Conviction</option>
@@ -115,10 +95,35 @@
                                 <option value="StipSDui">(Stipulated) Seal DUI</option>
                             </select>
                           </label>
+                    
+                    <hr>
+                    <label><span>Original Docket Sheet Number</span><input class="form-control" v-model="group.docketSheetNum" placeholder="Docket Num"></label>
+                    <div><label><span>Alleged Offense Date</span><input class="form-control" type="date" v-model="group.allegedOffenseDate" placeholder="Offense Date"></label>
+                    <label><span>Arrest Citation Date</span><input class="form-control" type="date" v-model="group.arrestCitationDate" placeholder="Arrest Citation Date"></label>
+                    </div>
+                    <div>
+                    <label width="400px">Offense Disposition<input class="form-control" v-model="group.offenseDisposition" placeholder="e.g. Dismissed By State"></label>
+                  
+                    <label class="checkbox-inline"><input v-model="group.isDismissed" type="checkbox"><span> Is Dismissed</span></label>
+                    </div>
+                    
+                 <hr>
+                    <label for="vsc-title"><span>Statue Title</span><input id="vsc-title" class="form-control" v-model="group.titleNum" placeholder="Title"></label>
+                    <label for="vsc-section"><span>Statute Section</span><input id="vsc-section" class="form-control" v-model="group.sectionNum" placeholder="Section"></label>
+                    <label><span>Offense Class</span>
+                    <select class="form-control" v-model="group.offenseClass">
+                        <option value="mis">Misdemeanor</option>
+                        <option value="fel">Felony</option>
+                    </select>
+                  </label>
+                    <p v-if="group.titleNum || group.sectionNum || group.offenseClass"><b>{{group.titleNum || '-'}} V.S.A. &sect; {{group.sectionNum || '-'}} ({{group.offenseClass || '-'}})</b></p>
+                                 <div>
+              
                           </div>
                   <div>
                     <button v-on:click="confirmDeleteCount($event,group.uid)" class="btn btn-danger">Delete Count</button>
                   </div>
+              </form>
                 </section>
             </div>
         </div>


### PR DESCRIPTION
Addresses issues https://github.com/codeforbtv/expunge-vt/issues/74 and https://github.com/codeforbtv/expunge-vt/issues/102.

In the edit view, all of the required fields have a bold asterisk and have the attribute "required" set on them. Additionally the required fields are now grouped together at the top of the count edit section to make it easier for an attorney to see all of the required fields. We are not doing any validation at this point.

A help message displays on the petitions page if all counts are set to "No Filing", and the blank checkout sheets are hidden.