### PR TITLE
devLog function

### DIFF
--- a/extensionDirectory/components.js
+++ b/extensionDirectory/components.js
@@ -93,8 +93,6 @@ Vue.component('pills-row', {
       if (!this.dob) return '';
       let fromTime = moment(value).diff(moment(this.dob));
       let duration = moment.duration(fromTime);
-
-      console.log(value, this.dob);
       return duration.asDays() / 365.25;
     },
   },
@@ -144,7 +142,6 @@ Vue.component('filing-type-heading', {
           return checkoutPhrases[i]['phrase'];
         }
       }
-      console.log(checkoutPhrases);
     },
   },
   template: `

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -13,9 +13,26 @@ $(document).on('keydown', function (e) {
   }
 });
 
+/**
+ * Replaces console.log() statements with a wrapper that prevents the extension from logging
+ * to the console unless it was installed by a developer. This will keep the console clean; a
+ * practice recommended for chrome extensions.
+ *
+ * @param {any} data Data to log to the console
+ * @todo find a way to make this reusuable, then delete the duplicate fn() in popup.js
+ */
+function devLog(data) {
+  // see https://developer.chrome.com/extensions/management#method-getSelf
+  chrome.management.getSelf(function (self) {
+    if (self.installType == 'development') {
+      console.log(data);
+    }
+  });
+}
+
 function initAfterVue() {
   //sets intital height of all text areas to show all text.
-  console.log(document.getElementsByTagName('body')[0].id);
+  devLog(document.getElementsByTagName('body')[0].id);
   if (document.getElementsByTagName('body')[0].id === 'filing-page') {
     initScrollDetection();
     setInitialExpandForTextAreas();
@@ -187,7 +204,7 @@ var app = new Vue({
     },
     saved: {
       handler() {
-        console.log('counts updated');
+        devLog('counts updated');
         this.saveCounts();
         app.$nextTick(function () {
           //call any vanilla js functions after update.
@@ -206,12 +223,13 @@ var app = new Vue({
         this.roleCoverLetterText = data['roleText'];
         this.coverLetterContent = data['letter'];
         this.stipDef = data['stipDefinition'];
-        console.log('adminConfig data has been set ', data);
+        devLog('adminConfig data has been set: ');
+        devLog(data);
       }.bind(this)
     );
   },
   mounted() {
-    console.log('App mounted!');
+    devLog('App mounted!');
     this.loadAll();
     detectChangesInChromeStorage();
 
@@ -220,18 +238,18 @@ var app = new Vue({
   },
   methods: {
     saveSettings: function () {
-      // console.log("save settings", app.settings)
+      // devLog("save settings", app.settings)
       settingString = JSON.stringify(this.settings);
       localStorage.setItem('localExpungeVTSettings', settingString);
     },
     saveResponses: function () {
-      console.log('save responses');
+      devLog('save responses');
       chrome.storage.local.set({
         responses: app.responses,
       });
     },
     saveCounts: function () {
-      console.log('saving counts');
+      devLog('saving counts');
       chrome.storage.local.set({
         counts: app.saved,
       });
@@ -240,27 +258,27 @@ var app = new Vue({
       if (callback === undefined) {
         callback = function () {};
       }
-      console.log(localStorage.getItem('localExpungeVTSettings'));
+      devLog(localStorage.getItem('localExpungeVTSettings'));
       localResult = JSON.parse(localStorage.getItem('localExpungeVTSettings'));
       if (
         localResult !== undefined &&
         localResult !== '' &&
         localResult !== null
       ) {
-        console.log('settings found');
+        devLog('settings found');
         this.settings = localResult;
-        console.log(this.settings);
+        devLog(this.settings);
       } else {
-        console.log('No settings found, saving default settings');
+        devLog('No settings found, saving default settings');
         this.saveSettings();
       }
 
       chrome.storage.local.get(function (result) {
         //test if we have any data
-        console.log('loading all');
-        console.log(JSON.stringify(result));
+        devLog('loading all');
+        devLog(JSON.stringify(result));
         if (result.counts !== undefined) {
-          console.log(result.counts);
+          devLog(result.counts);
           app.saved = result.counts;
         }
 
@@ -279,7 +297,7 @@ var app = new Vue({
       // get all counties that have counts associated with them
       var filingCounties = this.groupByCounty(counts);
 
-      console.log(
+      devLog(
         'there are ' +
           filingCounties.length +
           ' counties for ' +
@@ -305,7 +323,7 @@ var app = new Vue({
           allEligibleCountsForThisCounty
         );
 
-        console.log(
+        devLog(
           'there are ' +
             filingsForThisCounty.length +
             ' different filings needed in ' +
@@ -720,7 +738,7 @@ var app = new Vue({
     },
     returnCountyContact: function (cty) {
       allCounties = this.countiesContact;
-      console.log('Number: ' + allCounties[cty]);
+      devLog('Number: ' + allCounties[cty]);
       return allCounties[cty];
     },
     proSeFromRole: function (preparerRole) {

--- a/extensionDirectory/popup.js
+++ b/extensionDirectory/popup.js
@@ -468,7 +468,7 @@ function getVTCOCountInfo(rawData) {
       );
       var decodedString = dom.body.textContent;
 
-      console.log(decodedString);
+      devLog(decodedString);
       countObject['description'] = decodedString;
 
       counts.push(countObject);
@@ -576,6 +576,22 @@ function processCountLine1(countLine1, countNum, rawData) {
     console.log('Error:' + err);
   }
 }
+
+/**
+ * Replaces console.log() statements with a wrapper that prevents the extension from logging
+ * to the console unless it was installed by a developer. This will keep the console clean; a
+ * practice recommended for chrome extensions.
+ *
+ * @param {any} data Data to log to the console
+ */
+function devLog(data) {
+  chrome.management.getSelf(function (self) {
+    if (self.installType == 'development') {
+      console.log(data);
+    }
+  });
+}
+
 /**
  * A helper function to convert dates into a standard format
  * used consistently throughout this extension.

--- a/extensionDirectory/popup.js
+++ b/extensionDirectory/popup.js
@@ -585,6 +585,7 @@ function processCountLine1(countLine1, countNum, rawData) {
  * @param {any} data Data to log to the console
  */
 function devLog(data) {
+  // see https://developer.chrome.com/extensions/management#method-getSelf
   chrome.management.getSelf(function (self) {
     if (self.installType == 'development') {
       console.log(data);

--- a/extensionDirectory/popup.js
+++ b/extensionDirectory/popup.js
@@ -57,7 +57,7 @@ function appendDataWithConfirmation(newData, oldData) {
   var totalNumMatchingExistingCounts = 0;
   for (count in newCounts) {
     var currentCount = newCounts[count];
-    console.log(currentCount.uid);
+    devLog(currentCount.uid);
     var numMatchingExistingCounts = oldData.counts.filter(
       (count) => count.uid === currentCount.uid
     ).length;
@@ -382,8 +382,8 @@ function getOdysseyCountInfo(docket) {
   });
 
   // return parsed offenses
-  console.log('Parsed Offenses: ');
-  console.log(offenseArray);
+  devLog('Parsed Offenses: ');
+  devLog(offenseArray);
   return offenseArray;
 }
 
@@ -457,7 +457,7 @@ function getVTCOCountInfo(rawData) {
     } else {
       //Catch Line 2 of each count
       description = allCountsArray[i].trim();
-      console.log('description: ' + description);
+      devLog('description: ' + description);
       description = description.replace(/\//g, ' / ');
       description = description.replace(/\s\s/g, ' ');
 
@@ -488,7 +488,7 @@ function processCountLine1(countLine1, countNum, rawData) {
   //find location of fel/mis
   felMisLocation = countLine1Array.findIndex(isFelOrMisd);
 
-  console.log(countLine1Array);
+  devLog(countLine1Array);
   //get section string(s) beginnging at index 5 - after title
   let offenseSection = '';
   for (j = 5; j < felMisLocation; j++) {
@@ -555,7 +555,7 @@ function processCountLine1(countLine1, countNum, rawData) {
     countObject['allegedOffenseDate'] = formatDate(allegedOffenseDate.trim());
   } catch (err) {
     countObject['allegedOffenseDate'] = '';
-    console.log('Error:' + err);
+    devLog('Error:' + err);
   }
 
   //Get Arrest/citation date:
@@ -573,7 +573,7 @@ function processCountLine1(countLine1, countNum, rawData) {
     countObject['arrestCitationDate'] = formatDate(arrestCitationDate.trim());
   } catch (err) {
     countObject['arrestCitationDate'] = '';
-    console.log('Error:' + err);
+    devLog('Error:' + err);
   }
 }
 


### PR DESCRIPTION
Some code-cleanup which replaces all `console.log()` statements with a new `devLog()` function that only prints to the console in development mode (eg, when loading extension via the "unpack extension" button). This should keep the console a bit cleaner for anyone using the extension.