### PR TITLE
Link docket numbers in extension popup

### DIFF
--- a/extensionDirectory/payload.js
+++ b/extensionDirectory/payload.js
@@ -1,5 +1,6 @@
 docketData = {
   domain: window.location.hostname,
+  url: window.location.href,
   rawDocket: null,
 };
 

--- a/extensionDirectory/popup.html
+++ b/extensionDirectory/popup.html
@@ -178,8 +178,10 @@
                     <div class="card-header__description btn btn-link btn-sm">
                       <p v-if="count.docketNum">
                         <b
-                          >{{count.docketNum}} {{count.county | toCountyCode
-                          }}</b
+                          ><a v-bind:href="count.url" target="_blank">
+                            {{count.docketNum}} {{count.county | toCountyCode
+                            }}</a
+                          ></b
                         >
                       </p>
                       <p v-if="count.description">

--- a/extensionDirectory/popup.html
+++ b/extensionDirectory/popup.html
@@ -87,8 +87,7 @@
         </a>
         <a target="_blank" href="disclaimer.html" class="title-page__link">
           <p style="padding-bottom: 20px;">
-            Terms &amp; Conditions <i class="fas fa-external-link-alt"></i
-            >
+            Terms &amp; Conditions <i class="fas fa-external-link-alt"></i>
           </p>
         </a>
       </div>
@@ -177,8 +176,8 @@
                   <div id="description-date" class="card-header__meta-data">
                     <div class="card-header__description btn btn-link btn-sm">
                       <p v-if="count.docketNum">
-                        <b
-                          ><a v-bind:href="count.url" target="_blank">
+                        <b>
+                          <a v-bind:href="count.url" target="_blank">
                             {{count.docketNum}} {{count.county | toCountyCode
                             }}</a
                           ></b

--- a/extensionDirectory/popup.js
+++ b/extensionDirectory/popup.js
@@ -9,7 +9,7 @@ function initListeners() {
     switch (rawDocketData.domain) {
       // VT COURTS ONLINE
       case 'secure.vermont.gov': {
-        parsedData = getVTCOPetitionerInfo(rawDocketData.rawDocket);
+        parsedData = getVTCOPetitionerInfo(rawDocketData);
         break;
       }
       // ODYSSEY
@@ -393,8 +393,9 @@ function getOdysseyCountInfo(docket, docketUrl) {
  * Parses the VTCO docket data and returns object with parsed data
  * @param {string} rawData The content of the 'pre' element that VTCO uses to wrap it's docket info
  */
-function getVTCOPetitionerInfo(rawData) {
+function getVTCOPetitionerInfo(data) {
   //Get Defendant Name
+  const rawData = data.rawDocket; // this is the 'pre' element wraps VTCOs docket info
   nameLocation = nthIndex(rawData, 'Defendant:', 1) + 15;
   nameLocationEnd = nthIndex(rawData, 'DOB:', 1) - 40;
   defName = rawData.substring(nameLocation, nameLocationEnd);
@@ -429,13 +430,19 @@ function getVTCOPetitionerInfo(rawData) {
     defName: defName,
     defDOB: formatDate(defDOB),
     defAddress: addressArray.join('\n'),
-    counts: getVTCOCountInfo(rawData),
+    counts: getVTCOCountInfo(rawData, data.url),
   };
 
   return parsedData;
 }
 
-function getVTCOCountInfo(rawData) {
+/**
+ * Function to parse out the criminal counts visible on a VCOL docket
+ * @param {string} rawData The docket 'pre' element
+ * @param {string} docketUrl The url of this count's docket
+ * @returns {array} An array of criminal count objects
+ */
+function getVTCOCountInfo(rawData, docketUrl) {
   divider =
     '================================================================================';
 
@@ -472,6 +479,7 @@ function getVTCOCountInfo(rawData) {
 
       console.log(decodedString);
       countObject['description'] = decodedString;
+      countObject['url'] = docketUrl;
 
       counts.push(countObject);
     }

--- a/extensionDirectory/popup.js
+++ b/extensionDirectory/popup.js
@@ -14,7 +14,7 @@ function initListeners() {
       }
       // ODYSSEY
       case 'publicportal.courts.vt.gov': {
-        parsedData = getOdysseyPetitionerInfo(rawDocketData.rawDocket);
+        parsedData = getOdysseyPetitionerInfo(rawDocketData);
         break;
       }
       default: {
@@ -160,12 +160,12 @@ class PetitionerCount {
 }
 
 /**
- * Parses Odyssey docket html and returns object with parsed data
- * @param {string} domString The html of the Odyssey docket
+ * Parses Odyssey docket data and returns object with parsed data.
+ * @param {object} docketData All the Odyssey docket info collected by payload.js
  */
-function getOdysseyPetitionerInfo(domString) {
+function getOdysseyPetitionerInfo(docketData) {
   try {
-    const docket = $($.parseHTML(domString));
+    const docket = $($.parseHTML(docketData.rawDocket));
     const partyInfo = docket
       .find('#party-info')
       .parent()
@@ -208,7 +208,7 @@ function getOdysseyPetitionerInfo(domString) {
     currentDocket.defDOB = formatDate(
       partyInfo.find("[label='DOB:'] .roa-value").text().trim()
     );
-    currentDocket.counts = getOdysseyCountInfo(docket);
+    currentDocket.counts = getOdysseyCountInfo(docket, docketData.url);
     return currentDocket;
   } catch (err) {
     alert('Petitioner Info Error: ' + err);
@@ -218,9 +218,10 @@ function getOdysseyPetitionerInfo(domString) {
 /**
  * Function to parse out the criminal counts visible on a docket
  * @param {jQuery obj} docket The Odyssey dom parsed as a jQuery object
+ * @param {string} docketUrl The url of this count's docket (Odyssey only)
  * @returns {array} An array of criminal count objects
  */
-function getOdysseyCountInfo(docket) {
+function getOdysseyCountInfo(docket, docketUrl) {
   // grab the offense table from docket
   const caseOffenseTable = docket
     .find('[data-header-text="Case Information"]')
@@ -282,6 +283,7 @@ function getOdysseyCountInfo(docket) {
         titleNum: statuteTitle[0],
         sectionNum: statuteSection[0],
         unparsedOffenseData: offenseData,
+        url: docketUrl,
       });
     }
   });

--- a/extensionDirectory/popup.js
+++ b/extensionDirectory/popup.js
@@ -218,7 +218,7 @@ function getOdysseyPetitionerInfo(docketData) {
 /**
  * Function to parse out the criminal counts visible on a docket
  * @param {jQuery obj} docket The Odyssey dom parsed as a jQuery object
- * @param {string} docketUrl The url of this count's docket (Odyssey only)
+ * @param {string} docketUrl The url of this count's docket
  * @returns {array} An array of criminal count objects
  */
 function getOdysseyCountInfo(docket, docketUrl) {
@@ -391,7 +391,7 @@ function getOdysseyCountInfo(docket, docketUrl) {
 
 /**
  * Parses the VTCO docket data and returns object with parsed data
- * @param {string} rawData The content of the 'pre' element that VTCO uses to wrap it's docket info
+ * @param {string} data The 'docketData' object from payload.js
  */
 function getVTCOPetitionerInfo(data) {
   //Get Defendant Name


### PR DESCRIPTION
This PR captures the url of the docket too and uses that to link the docket numbers so users can quickly navigate back to any of the dockets they're creating petitions for.

![image](https://user-images.githubusercontent.com/1809882/95152169-75383100-075a-11eb-8c2a-144dd70f4f35.png)
