### PR TITLE
Nov 2020 release

### DIFF
--- a/extensionDirectory/components.js
+++ b/extensionDirectory/components.js
@@ -17,7 +17,7 @@ Vue.component('docket-caption', {
 Vue.component('filing-nav', {
   template: `<div class="filing-nav no-print" id="filing-nav"> 
       <ol>
-        <li class="filing-nav__parent-link">
+        <li class="cover-sheet filing-nav__parent-link">
           <a href="#extra-documents">Cover Sheet</a>
           <ol>
             <li class="filing-nav__child-link">
@@ -32,8 +32,8 @@ Vue.component('filing-nav', {
         <li v-for="group in filings" class="filing-nav__parent-link">
         <a href v-bind:href="'#'+group.county">{{group.county}}</a>
         <ol>
-          <li v-for="filing in group.filings" class="filing-nav__child-link">
-            <a v-bind:href="'#'+filing.id">{{filing.title}}</a>
+          <li v-for="filing in group.filings" class="filing-nav__child-link" v-bind:class="'petition-type__'+filing.type">
+            <a v-bind:href="'#'+filing.id" v-bind:class="'petition-type__'+filing.type">{{filing.title}}</a>
             <p class="filing-nav__counts">{{filing.numCountsString}}, {{filing.numDocketsString}}</p>
           </li>
         </ol>

--- a/extensionDirectory/components.js
+++ b/extensionDirectory/components.js
@@ -99,6 +99,9 @@ Vue.component('pills-row', {
   },
 });
 
+/* TODO: implement or remove
+ * A seemingly useful component that returns a plain-english explaination of a given filing type.
+ */
 Vue.component('filing-type-heading', {
   methods: {
     getCheckoutPhrases(fType) {

--- a/extensionDirectory/components.js
+++ b/extensionDirectory/components.js
@@ -93,8 +93,6 @@ Vue.component('pills-row', {
       if (!this.dob) return '';
       let fromTime = moment(value).diff(moment(this.dob));
       let duration = moment.duration(fromTime);
-
-      console.log(value, this.dob);
       return duration.asDays() / 365.25;
     },
   },
@@ -144,7 +142,6 @@ Vue.component('filing-type-heading', {
           return checkoutPhrases[i]['phrase'];
         }
       }
-      console.log(checkoutPhrases);
     },
   },
   template: `

--- a/extensionDirectory/components.js
+++ b/extensionDirectory/components.js
@@ -32,8 +32,9 @@ Vue.component('filing-nav', {
         <li v-for="group in filings" class="filing-nav__parent-link">
         <a href v-bind:href="'#'+group.county">{{group.county}}</a>
         <ol>
-          <li v-for="filing in group.filings" class="filing-nav__child-link"><a v-bind:href="'#'+filing.id">{{filing.title}}</a>
-          <p class="filing-nav__counts">{{filing.numCountsString}}, {{filing.numDocketsString}}</p>
+          <li v-for="filing in group.filings" class="filing-nav__child-link">
+            <a v-bind:href="'#'+filing.id">{{filing.title}}</a>
+            <p class="filing-nav__counts">{{filing.numCountsString}}, {{filing.numDocketsString}}</p>
           </li>
         </ol>
         </li>

--- a/extensionDirectory/filings.css
+++ b/extensionDirectory/filings.css
@@ -121,13 +121,29 @@ a.btn {
 .filing-nav__parent-link a {
   color: #000;
 }
+
+/* TODO: cover sheet links probably shouldn't have a "filing" class - they aren't filings */
+.cover-sheet .filing-nav__child-link,
+.cover-sheet .filing-nav__child-link:last-child {
+  border-width: 0;
+}
+.filing-nav__child-link.petition-type__NoA,
+.filing-nav__child-link.petition-type__NoA a {
+  color: white;
+  background-color: #66b0ff;
+}
 .filing-nav__child-link {
   font-weight: normal;
   transition: box-shadow 0.1s ease-in-out, transform 0.1s ease-in-out;
   color: #007bff;
-  font-size: 1rem;
+  font-size: 16px;
   margin-left: 0;
-  padding-left: 10px;
+  border: 1px solid #66b0ff;
+  border-top-color: transparent;
+  border-bottom-color: transparent;
+}
+.filing-nav__child-link:last-child {
+  border-bottom: 1px solid #66b0ff;
 }
 .filing-nav__child-link a {
   color: #007bff;
@@ -136,13 +152,40 @@ a.btn {
 .active.filing-nav__child-link {
   box-shadow: -5px 0 0 0 #007bff;
   transform: translateX(5px);
+  border-right-width: 5px;
+  border-right-color: #007bff;
 }
 .filing-nav__counts {
-  color: #000;
+  color: #333;
   text-transform: uppercase;
   font-size: 12px;
   font-weight: bold;
-  padding-top: 0.4rem;
+  margin-bottom: 0.75em;
+}
+
+/* Move list numbers inside blue <li> borders */
+.filing-nav__child-link::marker {
+  color: transparent;
+}
+.filing-nav__parent-link ol {
+  list-style: none;
+  counter-reset: petition-counter;
+}
+li.filing-nav__child-link {
+  counter-increment: petition-counter;
+  padding-left: 30px;
+}
+li.filing-nav__child-link a::before {
+  content: counter(petition-counter) '. ';
+  padding: 5px;
+  font-size: 1rem;
+  position: absolute;
+  left: 24px;
+  text-align: right;
+  width: 2em;
+}
+li.filing-nav__child-link.active a::before {
+  left: 0px;
 }
 
 /* Title section above each document */

--- a/extensionDirectory/filings.css
+++ b/extensionDirectory/filings.css
@@ -104,7 +104,7 @@ a.btn {
   padding: 1rem;
   z-index: 9;
   background-color: #fff;
-  width: 15em;
+  width: 17em;
   overflow-y: scroll;
   padding-top: 40px;
 }
@@ -492,7 +492,7 @@ p.filing-dated-city {
     padding: 6rem;
     height: 100%;
     border: 2px solid #ddd;
-    margin-left: 17rem;
+    margin-left: 19rem;
     margin-right: auto;
     margin-top: 8rem;
     position: relative;

--- a/extensionDirectory/filings.html
+++ b/extensionDirectory/filings.html
@@ -142,14 +142,22 @@
         </div>
       </div>
 
+      <!-- If there are filings to dispalay... -->
       <template v-if="(numCountsToExpungeOrSeal + numCountsNoAction) > 0">
+
+        <!-- Page header & page actions -->
         <div v-if="petitioner.name" class="header-bar-wrapper no-print">
           <div class="header-bar">
             <h1>Filings for {{petitioner.name}}</h1>
             <div class="header-bar__controls">
-              <label v-if="numDockets > 1"
-                >Consolidate Petitions
+              <span>Consolidate by county: </span>
+              <label v-if="numDockets > 1">
+                <input type="checkbox" v-model="groupNoas"/>
+                NoA
+              </label>
+              <label v-if="numDockets > 1">
                 <input type="checkbox" v-model="groupCounts" />
+                Petitions
               </label>
               <button
                 v-on:click="printDocument"
@@ -180,6 +188,7 @@
 
         <filing-nav v-bind:filings="filings"></filing-nav>
 
+        <!-- Cover letter & checkout sheet wrapper -->
         <table class="extra-pages">
           <tbody>
             <tr>
@@ -192,10 +201,11 @@
                     >Terms and Conditions.</a
                   >
                 </section>
-                <!-- Begin Extra Documents -->
 
+                <!-- Begin Cover Sheet -->
                 <section class="extra-documents-top" id="extra-documents">
-                  <!-- Clinic Checkout Sheet -->
+                  
+                  <!-- Client Cover Letter -->
                   <article class="page" id="clinic-checkout">
                     <div class="document-meta-data no-print">
                       <p class="document-meta-data__title">Cover Letter</p>
@@ -322,10 +332,7 @@
                     </div>
                   </article>
 
-                  <!-- End Clinic Checkout Sheet -->
-
                   <!-- Client Checkout Sheet -->
-
                   <article class="page" id="client-checkout">
                     <div class="document-meta-data no-print">
                       <p class="document-meta-data__title">Checkout Sheet</p>
@@ -461,10 +468,9 @@
                     </div>
                   </article>
 
-                  <!-- End Client Checkout Sheet -->
                 </section>
+                <!-- End Cover Sheet -->
 
-                <!-- End Extra Documents -->
               </td>
             </tr>
           </tbody>
@@ -474,12 +480,16 @@
             </tr>
           </tfoot>
         </table>
+        <!-- Cover letter & checkout sheet wrapper -->
 
+        <!-- Petition wrapper -->
         <table v-if="filings.length != 0" class="all-filings">
           <tbody>
             <tr>
               <td>
                 <section v-for="group in filings" v-bind:id="group.county">
+
+                  <!-- Generic petition heading info -->
                   <article
                     class="page"
                     v-for="filing in group.filings"
@@ -532,11 +542,11 @@
                       </div>
 
                       <h1 class="filing-title">{{filing.title}}</h1>
+                      <!-- End generic petition heading info -->
 
                       <!-- Begin Unique Portion of Filings -->
 
                       <!-- Notice of Appearance -->
-
                       <div class="filing-body" v-if="filing.type == 'NoA'">
                         <p class="indent">
                           <template v-if="proSeFromRole(settings.role)">
@@ -650,7 +660,6 @@
                       </div>
 
                       <!-- (Stipulated) Petiton To Expunge Non Conviction -->
-
                       <div
                         class="filing-body"
                         v-if="filing.type == 'ExNC' || filing.type == 'StipExNC'"
@@ -738,7 +747,6 @@
                       </div>
 
                       <!-- (Stipulated) Petiton To Expunge Non-Crime -->
-
                       <div
                         class="filing-body"
                         v-if="filing.type == 'ExNCrim' || filing.type == 'StipExNCrim'"
@@ -819,7 +827,6 @@
                       </div>
 
                       <!-- (Stipulated) Petiton To Seal Conviction -->
-
                       <div
                         class="filing-body"
                         v-if="filing.type == 'SC' || filing.type == 'StipSC'"
@@ -903,7 +910,6 @@
                       </div>
 
                       <!-- (Stipulated) Petiton To Seal DUI Conviction -->
-
                       <div
                         class="filing-body"
                         v-if="filing.type == 'SDui' || filing.type == 'StipSDui'"
@@ -986,8 +992,8 @@
                           as
                         </p>
                       </div>
-
                       <!-- End Unique Portion of Filings -->
+
                       <template v-if="filing.type != 'NoA'">
                         <div class="filing-body__response">
                           <p
@@ -1002,7 +1008,7 @@
                         </div>
                       </template>
 
-                      <!-- Begin Closings -->
+                      <!-- Begin generic footer -->
                       <template v-if="filing.type != 'NoA'">
                         <div class="filing-closing">
                             <p class="filing-closing__salutation">
@@ -1064,8 +1070,8 @@
                                 </div>
                             </div>
                     </template>
+                    <!-- End generic footer -->
 
-                      <!-- End Closings -->
                     </div>
                   </article>
 
@@ -1082,6 +1088,7 @@
             </tr>
           </tfoot>
         </table>
+        <!-- End petition wrapper -->
 
         <div v-if="settings.forVla" class="footer">
           <p class="footer__company">Vermont Legal Aid, Inc.</p>
@@ -1092,6 +1099,8 @@
           <p class="footer__phone">{{settings['footer2']}}</p>
         </div>
       </template>
+
+      <!-- else show default "no filings" display -->
       <template v-else>
         <div class="no-filings">
           <p>
@@ -1111,6 +1120,7 @@
       </template>
     </div>
     <!-- End Vue App -->
+    
     <script id="script" src="components.js"></script>
     <script id="script" src="filings.js"></script>
     <script id="script" src="csv.js"></script>

--- a/extensionDirectory/filings.html
+++ b/extensionDirectory/filings.html
@@ -150,15 +150,17 @@
           <div class="header-bar">
             <h1>Filings for {{petitioner.name}}</h1>
             <div class="header-bar__controls">
-              <span>Consolidate by county: </span>
-              <label v-if="numDockets > 1">
-                <input type="checkbox" v-model="groupNoas"/>
-                NoA
-              </label>
-              <label v-if="numDockets > 1">
-                <input type="checkbox" v-model="groupCounts" />
-                Petitions
-              </label>
+              <div v-if="numDockets > 1">
+                <span>Consolidate by county: </span>
+                <label>
+                  <input type="checkbox" v-model="groupNoas"/>
+                  NoA
+                </label>
+                <label>
+                  <input type="checkbox" v-model="groupCounts" />
+                  Petitions
+                </label>
+              </div>
               <button
                 v-on:click="printDocument"
                 class="btn btn-primary no-print"

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -913,15 +913,22 @@ var app = new Vue({
           count.filingType === 'SDui' || count.filingType === 'StipSDui'
       );
     },
+    /* Checkes the computed `filings` property to see how many unique dockets there are */
     numDockets: function () {
-      var numDockets = this.saved.counts.filter((e, i) => {
-        return (
-          this.saved.counts.findIndex((x) => {
-            return x.docketNum == e.docketNum && x.county == e.county;
-          }) == i
-        );
-      });
-      return numDockets.length;
+      const dockets = this.filings
+        .map((f) =>
+          f.filings
+            .map((f2) => f2.docketNums.map((d) => d.string).flat())
+            .flat()
+        )
+        .flat();
+      const uniqueDockets = dockets.reduce((acc, n) => {
+        if (!acc.includes(n)) {
+          acc.push(n);
+        }
+        return acc;
+      }, []);
+      return uniqueDockets.length;
     },
     csvFilename: function () {
       var date = new Date();

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -13,9 +13,26 @@ $(document).on('keydown', function (e) {
   }
 });
 
+/**
+ * Replaces console.log() statements with a wrapper that prevents the extension from logging
+ * to the console unless it was installed by a developer. This will keep the console clean; a
+ * practice recommended for chrome extensions.
+ *
+ * @param {any} data Data to log to the console
+ * @todo find a way to make this reusuable, then delete the duplicate fn() in popup.js
+ */
+function devLog(data) {
+  // see https://developer.chrome.com/extensions/management#method-getSelf
+  chrome.management.getSelf(function (self) {
+    if (self.installType == 'development') {
+      console.log(data);
+    }
+  });
+}
+
 function initAfterVue() {
   //sets intital height of all text areas to show all text.
-  console.log(document.getElementsByTagName('body')[0].id);
+  devLog(document.getElementsByTagName('body')[0].id);
   if (document.getElementsByTagName('body')[0].id === 'filing-page') {
     initScrollDetection();
     setInitialExpandForTextAreas();
@@ -187,7 +204,7 @@ var app = new Vue({
     },
     saved: {
       handler() {
-        console.log('counts updated');
+        devLog('counts updated');
         this.saveCounts();
         app.$nextTick(function () {
           //call any vanilla js functions after update.
@@ -206,12 +223,13 @@ var app = new Vue({
         this.roleCoverLetterText = data['roleText'];
         this.coverLetterContent = data['letter'];
         this.stipDef = data['stipDefinition'];
-        console.log('adminConfig data has been set ', data);
+        devLog('adminConfig data has been set: ');
+        devLog(data);
       }.bind(this)
     );
   },
   mounted() {
-    console.log('App mounted!');
+    devLog('App mounted!');
     this.loadAll();
     detectChangesInChromeStorage();
 
@@ -220,18 +238,18 @@ var app = new Vue({
   },
   methods: {
     saveSettings: function () {
-      // console.log("save settings", app.settings)
+      // devLog("save settings", app.settings)
       settingString = JSON.stringify(this.settings);
       localStorage.setItem('localExpungeVTSettings', settingString);
     },
     saveResponses: function () {
-      console.log('save responses');
+      devLog('save responses');
       chrome.storage.local.set({
         responses: app.responses,
       });
     },
     saveCounts: function () {
-      console.log('saving counts');
+      devLog('saving counts');
       chrome.storage.local.set({
         counts: app.saved,
       });
@@ -240,27 +258,27 @@ var app = new Vue({
       if (callback === undefined) {
         callback = function () {};
       }
-      console.log(localStorage.getItem('localExpungeVTSettings'));
+      devLog(localStorage.getItem('localExpungeVTSettings'));
       localResult = JSON.parse(localStorage.getItem('localExpungeVTSettings'));
       if (
         localResult !== undefined &&
         localResult !== '' &&
         localResult !== null
       ) {
-        console.log('settings found');
+        devLog('settings found');
         this.settings = localResult;
-        console.log(this.settings);
+        devLog(this.settings);
       } else {
-        console.log('No settings found, saving default settings');
+        devLog('No settings found, saving default settings');
         this.saveSettings();
       }
 
       chrome.storage.local.get(function (result) {
         //test if we have any data
-        console.log('loading all');
-        console.log(JSON.stringify(result));
+        devLog('loading all');
+        devLog(JSON.stringify(result));
         if (result.counts !== undefined) {
-          console.log(result.counts);
+          devLog(result.counts);
           app.saved = result.counts;
         }
 
@@ -279,7 +297,7 @@ var app = new Vue({
       // get all counties that have counts associated with them
       var filingCounties = this.groupByCounty(counts);
 
-      console.log(
+      devLog(
         'there are ' +
           filingCounties.length +
           ' counties for ' +
@@ -305,7 +323,7 @@ var app = new Vue({
           allEligibleCountsForThisCounty
         );
 
-        console.log(
+        devLog(
           'there are ' +
             filingsForThisCounty.length +
             ' different filings needed in ' +
@@ -720,7 +738,7 @@ var app = new Vue({
     },
     returnCountyContact: function (cty) {
       allCounties = this.countiesContact;
-      console.log('Number: ' + allCounties[cty]);
+      devLog('Number: ' + allCounties[cty]);
       return allCounties[cty];
     },
     proSeFromRole: function (preparerRole) {

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -371,8 +371,8 @@ var app = new Vue({
         );
 
         //iterate through the filing types needed for this county and push them into the array
-        for (var filingIndex in filingsForThisCounty) {
-          var filingType = filingsForThisCounty[filingIndex];
+        for (var i in filingsForThisCounty) {
+          var filingType = filingsForThisCounty[i];
 
           //if the filing is not one we're going to need a petition for, let's skip to the next filing type
           if (!this.isFileable(filingType)) continue;

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -78,12 +78,13 @@ function detectChangesInChromeStorage() {
 }
 
 function initScrollDetection() {
-  //initates the scrollspy for the filing-nav module.
+  // initates the scrollspy for the filing-nav module.
+  // see: https://www.npmjs.com/package/gumshoejs#nested-navigation
   var spy = new Gumshoe('#filing-nav a', {
     nested: true,
     nestedClass: 'active-parent',
     offset: 200, // how far from the top of the page to activate a content area
-    reflow: true, // if true, listen for reflows
+    reflow: true, // will update when the navigation chages (eg, user adds/changes a petition, or consolidates petitions/NOAs)
   });
 }
 
@@ -475,20 +476,25 @@ var app = new Vue({
 
     /*
      * Inserts an NOA each time the docket changes in the array of filings.
-     * @param {object} filings      An array of filing objects that needs some NOAs added to it
+     * @param {object[]} filings      An array of filing objects that needs some NOAs added to it
      */
     insertNOAsForEachDocket: function (filings) {
       let lastDocketNum = '';
       let filingsWithNOAs = [];
 
-      // loop over all the filings
-      for (var i = 0; i < filings.length; i++) {
-        const thisFiling = filings[i];
+      // sorted filings by docket
+      var sortedFilings = filings.sort((a, b) =>
+        a.docketNums[0].num > b.docketNums[0].num ? 1 : -1
+      );
+
+      // loop over all the sortedFilings
+      for (var i = 0; i < sortedFilings.length; i++) {
+        const thisFiling = sortedFilings[i];
         const currDocketNum = thisFiling.docketNums[0].string;
 
         // Conditionally insert a NOA at the beginning of each new string of docket petitions
         if (lastDocketNum != currDocketNum) {
-          const docketCounts = filings
+          const docketCounts = sortedFilings
             .map(function (f) {
               if (
                 f.docketSheetNums.filter((n) => n.num == currDocketNum).length >
@@ -627,17 +633,17 @@ var app = new Vue({
         case 'ExNC':
           return 'Petition to Expunge Non-Conviction';
         case 'StipExNCrim':
-          return 'Stipulated Petition to Expunge Conviction';
+          return 'Stipulated Petition to Expunge Non-Criminal Conviction';
         case 'ExNCrim':
-          return 'Petition to Expunge Conviction';
+          return 'Petition to Expunge Non-Criminal Conviction';
         case 'StipSC':
           return 'Stipulated Petition to Seal Conviction';
         case 'SC':
           return 'Petition to Seal Conviction';
         case 'StipSDui':
-          return 'Stipulated Petition to Seal Conviction';
+          return 'Stipulated Petition to Seal DUI Conviction';
         case 'SDui':
-          return 'Petition to Seal Conviction';
+          return 'Petition to Seal DUI Conviction';
         case 'X':
           return 'Ineligible';
         default:

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -668,6 +668,10 @@ var app = new Vue({
       );
       return this.makeFilingObject(countsOnThisFiling, filingType, county);
     },
+    /*
+     * Creates a filing object from data provided.
+     * NOTE: will fail without explaination on civil violations b/c this presumes `counts` is a non-empty array
+     */
     makeFilingObject: function (counts, filingType, county) {
       var countsOnThisFiling = counts;
       var numCounts = countsOnThisFiling.length;

--- a/extensionDirectory/manifest.json
+++ b/extensionDirectory/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "ExpungeVT!",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "description": " Odisee Edition - Expunge and seal Vermont records with ease!",
     "permissions": ["storage",
                     "declarativeContent",

--- a/extensionDirectory/payload.js
+++ b/extensionDirectory/payload.js
@@ -1,5 +1,6 @@
 docketData = {
   domain: window.location.hostname,
+  url: window.location.href,
   rawDocket: null,
 };
 

--- a/extensionDirectory/popup.html
+++ b/extensionDirectory/popup.html
@@ -87,8 +87,7 @@
         </a>
         <a target="_blank" href="disclaimer.html" class="title-page__link">
           <p style="padding-bottom: 20px;">
-            Terms &amp; Conditions <i class="fas fa-external-link-alt"></i
-            >
+            Terms &amp; Conditions <i class="fas fa-external-link-alt"></i>
           </p>
         </a>
       </div>
@@ -177,9 +176,11 @@
                   <div id="description-date" class="card-header__meta-data">
                     <div class="card-header__description btn btn-link btn-sm">
                       <p v-if="count.docketNum">
-                        <b
-                          >{{count.docketNum}} {{count.county | toCountyCode
-                          }}</b
+                        <b>
+                          <a v-bind:href="count.url" target="_blank">
+                            {{count.docketNum}} {{count.county | toCountyCode
+                            }}</a
+                          ></b
                         >
                       </p>
                       <p v-if="count.description">

--- a/extensionDirectory/popup.js
+++ b/extensionDirectory/popup.js
@@ -57,7 +57,7 @@ function appendDataWithConfirmation(newData, oldData) {
   var totalNumMatchingExistingCounts = 0;
   for (count in newCounts) {
     var currentCount = newCounts[count];
-    console.log(currentCount.uid);
+    devLog(currentCount.uid);
     var numMatchingExistingCounts = oldData.counts.filter(
       (count) => count.uid === currentCount.uid
     ).length;
@@ -384,8 +384,8 @@ function getOdysseyCountInfo(docket, docketUrl) {
   });
 
   // return parsed offenses
-  console.log('Parsed Offenses: ');
-  console.log(offenseArray);
+  devLog('Parsed Offenses: ');
+  devLog(offenseArray);
   return offenseArray;
 }
 
@@ -466,7 +466,7 @@ function getVTCOCountInfo(rawData, docketUrl) {
     } else {
       //Catch Line 2 of each count
       description = allCountsArray[i].trim();
-      console.log('description: ' + description);
+      devLog('description: ' + description);
       description = description.replace(/\//g, ' / ');
       description = description.replace(/\s\s/g, ' ');
 
@@ -477,7 +477,7 @@ function getVTCOCountInfo(rawData, docketUrl) {
       );
       var decodedString = dom.body.textContent;
 
-      console.log(decodedString);
+      devLog(decodedString);
       countObject['description'] = decodedString;
       countObject['url'] = docketUrl;
 
@@ -499,7 +499,7 @@ function processCountLine1(countLine1, countNum, rawData) {
   felMisLocation = countLine1Array.findIndex(isFelOrMisd);
 
   // TODO: conditionally display console.log content
-  console.log(countLine1Array);
+  devLog(countLine1Array);
   //get section string(s) beginnging at index 5 - after title
   let offenseSection = '';
   for (j = 5; j < felMisLocation; j++) {
@@ -566,7 +566,7 @@ function processCountLine1(countLine1, countNum, rawData) {
     countObject['allegedOffenseDate'] = formatDate(allegedOffenseDate.trim());
   } catch (err) {
     countObject['allegedOffenseDate'] = '';
-    console.log('Error:' + err);
+    devLog('Error:' + err);
   }
 
   //Get Arrest/citation date:
@@ -584,9 +584,26 @@ function processCountLine1(countLine1, countNum, rawData) {
     countObject['arrestCitationDate'] = formatDate(arrestCitationDate.trim());
   } catch (err) {
     countObject['arrestCitationDate'] = '';
-    console.log('Error:' + err);
+    devLog('Error:' + err);
   }
 }
+
+/**
+ * Replaces console.log() statements with a wrapper that prevents the extension from logging
+ * to the console unless it was installed by a developer. This will keep the console clean; a
+ * practice recommended for chrome extensions.
+ *
+ * @param {any} data Data to log to the console
+ */
+function devLog(data) {
+  // see https://developer.chrome.com/extensions/management#method-getSelf
+  chrome.management.getSelf(function (self) {
+    if (self.installType == 'development') {
+      console.log(data);
+    }
+  });
+}
+
 /**
  * A helper function to convert dates into a standard format
  * used consistently throughout this extension.

--- a/extensionDirectory/popup.js
+++ b/extensionDirectory/popup.js
@@ -200,7 +200,11 @@ function getOdysseyPetitionerInfo(docketData) {
       }
     });
 
-    currentDocket.defName = partyInfo.find('td:first-of-type').html().trim();
+    // get name from page and reformat it if necessary
+    // Note: it would be more durable to parse the fname, lname and any titles (Jr, III, etc) - possible refactor.
+    const rawName = partyInfo.find('td:first-of-type').html().trim();
+    currentDocket.defName = formatPetitionersName(rawName);
+
     currentDocket.defDOB = partyInfo
       .find("[label='DOB:'] .roa-value")
       .text()
@@ -212,6 +216,21 @@ function getOdysseyPetitionerInfo(docketData) {
     return currentDocket;
   } catch (err) {
     alert('Petitioner Info Error: ' + err);
+  }
+}
+
+/**
+ * A helper method to format names as "Firstname Lastname"
+ * @param {string} fullTextName A person's name which may, or may not, be formatted as "Lastname, Firstname"
+ */
+function formatPetitionersName(fullTextName) {
+  const commaIndex = fullTextName.indexOf(',');
+  if (commaIndex == -1) {
+    return fullTextName;
+  } else {
+    const lname = fullTextName.substring(0, commaIndex);
+    const fname = fullTextName.substring(commaIndex + 1);
+    return `${fname.trim()} ${lname.trim()}`;
   }
 }
 

--- a/extensionDirectory/popup.js
+++ b/extensionDirectory/popup.js
@@ -704,7 +704,7 @@ function generateCountUID(offense) {
     offense.docketSheetNum +
     `_Count${offense.countNum}_` +
     `${offense.description}_` +
-    checkDisposition(offense.offenseDisposition);
+    beautifyDisposition(offense.offenseDisposition);
   return uid.split(' ').join('_');
 }
 

--- a/extensionDirectory/popup.js
+++ b/extensionDirectory/popup.js
@@ -487,7 +487,7 @@ function getVTCOCountInfo(rawData, docketUrl) {
   return counts;
 }
 
-//Break line one of a count into its individual fields
+// When parsing VCOL data, break line one of a count into its individual fields
 function processCountLine1(countLine1, countNum, rawData) {
   //Break into array and remove spaces
   countLine1Array = countLine1.split(' ');
@@ -498,6 +498,7 @@ function processCountLine1(countLine1, countNum, rawData) {
   //find location of fel/mis
   felMisLocation = countLine1Array.findIndex(isFelOrMisd);
 
+  // TODO: conditionally display console.log content
   console.log(countLine1Array);
   //get section string(s) beginnging at index 5 - after title
   let offenseSection = '';
@@ -526,10 +527,10 @@ function processCountLine1(countLine1, countNum, rawData) {
     docketSheetNum +
     countLine1Array[0] +
     countLine1Array[1] +
-    checkDisposition(disposition);
+    beautifyDisposition(disposition);
   uid = uid.split(' ').join('_');
 
-  offenseDisposition = checkDisposition(disposition);
+  offenseDisposition = beautifyDisposition(disposition);
   dispositionDate = countLine1Array[felMisLocation + 1];
   //Create count object with all count line 1 items
   countObject = {
@@ -610,13 +611,7 @@ function isDismissed(offenseDisposition) {
     return false;
   }
 }
-function checkDisposition(string) {
-  if (string.trim() == '') {
-    return 'Pending';
-  } else {
-    return string;
-  }
-}
+
 function isFelOrMisd(element) {
   if (element === 'mis' || element === 'fel') {
     return element;
@@ -659,6 +654,26 @@ function nthIndex(str, subStr, n) {
     if (i < 0) break;
   }
   return i;
+}
+
+/**
+ * Helper function to clean up the disposition text, if possible
+ * @param {string} text The text to try to replace
+ */
+function beautifyDisposition(text) {
+  switch (text.trim()) {
+    // replace empty disposition strings with 'pending'
+    case '':
+      return 'Pending';
+
+    // common truncation on VCOL
+    case 'Plea guilty by wai':
+      return 'Plea guilty by waiver';
+
+    // otherwise return the trimmed original text
+    default:
+      return text;
+  }
 }
 
 /**


### PR DESCRIPTION
This release includes these features:

- #136: non-functional readability refactors
- #135: a consolidate button for Notice of Appearance (NoA) filings 
- #134: make docket numbers in the popup links that open the docket in a new tab
- #133: a wrapper around console.log() statements so they are only displayed in dev
- #132: quick text fix to change "waiv" to "waiver"
- #142 Bug: odyssey name format
- #141 Nav Subtitles (changing the text depending on how petitions are/aren't grouped)
- #140 Order by docket (order dockets by docket number when grouping NoAs together)
- #139 Toggle checkbox label too (hide "consolidation" label when there's only 1 docket)
- #138 Nav styling (whole mess of styling)
