### PR TITLE
Nav styling

### DIFF
--- a/extensionDirectory/components.js
+++ b/extensionDirectory/components.js
@@ -17,7 +17,7 @@ Vue.component('docket-caption', {
 Vue.component('filing-nav', {
   template: `<div class="filing-nav no-print" id="filing-nav"> 
       <ol>
-        <li class="filing-nav__parent-link">
+        <li class="cover-sheet filing-nav__parent-link">
           <a href="#extra-documents">Cover Sheet</a>
           <ol>
             <li class="filing-nav__child-link">
@@ -32,8 +32,8 @@ Vue.component('filing-nav', {
         <li v-for="group in filings" class="filing-nav__parent-link">
         <a href v-bind:href="'#'+group.county">{{group.county}}</a>
         <ol>
-          <li v-for="filing in group.filings" class="filing-nav__child-link">
-            <a v-bind:href="'#'+filing.id">{{filing.title}}</a>
+          <li v-for="filing in group.filings" class="filing-nav__child-link" v-bind:class="'petition-type__'+filing.type">
+            <a v-bind:href="'#'+filing.id" v-bind:class="'petition-type__'+filing.type">{{filing.title}}</a>
             <p class="filing-nav__counts">{{filing.numCountsString}}, {{filing.numDocketsString}}</p>
           </li>
         </ol>

--- a/extensionDirectory/components.js
+++ b/extensionDirectory/components.js
@@ -32,8 +32,9 @@ Vue.component('filing-nav', {
         <li v-for="group in filings" class="filing-nav__parent-link">
         <a href v-bind:href="'#'+group.county">{{group.county}}</a>
         <ol>
-          <li v-for="filing in group.filings" class="filing-nav__child-link"><a v-bind:href="'#'+filing.id">{{filing.title}}</a>
-          <p class="filing-nav__counts">{{filing.numCountsString}}, {{filing.numDocketsString}}</p>
+          <li v-for="filing in group.filings" class="filing-nav__child-link">
+            <a v-bind:href="'#'+filing.id">{{filing.title}}</a>
+            <p class="filing-nav__counts">{{filing.numCountsString}}, {{filing.numDocketsString}}</p>
           </li>
         </ol>
         </li>

--- a/extensionDirectory/filings.css
+++ b/extensionDirectory/filings.css
@@ -121,13 +121,29 @@ a.btn {
 .filing-nav__parent-link a {
   color: #000;
 }
+
+/* TODO: cover sheet links probably shouldn't have a "filing" class - they aren't filings */
+.cover-sheet .filing-nav__child-link,
+.cover-sheet .filing-nav__child-link:last-child {
+  border-width: 0;
+}
+.filing-nav__child-link.petition-type__NoA,
+.filing-nav__child-link.petition-type__NoA a {
+  color: white;
+  background-color: #66b0ff;
+}
 .filing-nav__child-link {
   font-weight: normal;
   transition: box-shadow 0.1s ease-in-out, transform 0.1s ease-in-out;
   color: #007bff;
-  font-size: 1rem;
+  font-size: 16px;
   margin-left: 0;
-  padding-left: 10px;
+  border: 1px solid #66b0ff;
+  border-top-color: transparent;
+  border-bottom-color: transparent;
+}
+.filing-nav__child-link:last-child {
+  border-bottom: 1px solid #66b0ff;
 }
 .filing-nav__child-link a {
   color: #007bff;
@@ -136,13 +152,40 @@ a.btn {
 .active.filing-nav__child-link {
   box-shadow: -5px 0 0 0 #007bff;
   transform: translateX(5px);
+  border-right-width: 5px;
+  border-right-color: #007bff;
 }
 .filing-nav__counts {
-  color: #000;
+  color: #333;
   text-transform: uppercase;
   font-size: 12px;
   font-weight: bold;
-  padding-top: 0.4rem;
+  margin-bottom: 0.75em;
+}
+
+/* Move list numbers inside blue <li> borders */
+.filing-nav__child-link::marker {
+  color: transparent;
+}
+.filing-nav__parent-link ol {
+  list-style: none;
+  counter-reset: petition-counter;
+}
+li.filing-nav__child-link {
+  counter-increment: petition-counter;
+  padding-left: 30px;
+}
+li.filing-nav__child-link a::before {
+  content: counter(petition-counter) '. ';
+  padding: 5px;
+  font-size: 1rem;
+  position: absolute;
+  left: 24px;
+  text-align: right;
+  width: 2em;
+}
+li.filing-nav__child-link.active a::before {
+  left: 0px;
 }
 
 /* Title section above each document */

--- a/extensionDirectory/filings.html
+++ b/extensionDirectory/filings.html
@@ -150,16 +150,16 @@
           <div class="header-bar">
             <h1>Filings for {{petitioner.name}}</h1>
             <div class="header-bar__controls">
-              <span>Consolidate: </span>
+              <span>Consolidate by county: </span>
+              <!-- TODO: can you consoliate NoA without Petitions? Or the other way around? May need logic to handle an overriding case... -->
+              <label v-if="numDockets > 1">
+                <input type="checkbox" v-model="groupNoas"/>
+                NoA
+              </label>
               <label v-if="numDockets > 1">
                 <input type="checkbox" v-model="groupCounts" />
                 Petitions
               </label>
-              <!-- TODO: can you consoliate NoA without Petitions? Or the other way around? May need logic to handle an overriding case... -->
-              <!-- <label v-if="numDockets > 1">
-                <input type="checkbox" v-model="groupNoas"/>
-                NoA
-              </label> -->
               <button
                 v-on:click="printDocument"
                 class="btn btn-primary no-print"

--- a/extensionDirectory/filings.html
+++ b/extensionDirectory/filings.html
@@ -155,6 +155,7 @@
                 <input type="checkbox" v-model="groupCounts" />
                 Petitions
               </label>
+              <!-- TODO: can you consoliate NoA without Petitions? Or the other way around? May need logic to handle an overriding case... -->
               <label v-if="numDockets > 1">
                 <input type="checkbox" v-model="groupNoas"/>
                 NoA

--- a/extensionDirectory/filings.html
+++ b/extensionDirectory/filings.html
@@ -156,10 +156,10 @@
                 Petitions
               </label>
               <!-- TODO: can you consoliate NoA without Petitions? Or the other way around? May need logic to handle an overriding case... -->
-              <label v-if="numDockets > 1">
+              <!-- <label v-if="numDockets > 1">
                 <input type="checkbox" v-model="groupNoas"/>
                 NoA
-              </label>
+              </label> -->
               <button
                 v-on:click="printDocument"
                 class="btn btn-primary no-print"

--- a/extensionDirectory/filings.html
+++ b/extensionDirectory/filings.html
@@ -142,7 +142,10 @@
         </div>
       </div>
 
+      <!-- If there are filings to dispalay... -->
       <template v-if="(numCountsToExpungeOrSeal + numCountsNoAction) > 0">
+
+        <!-- Page header & page actions -->
         <div v-if="petitioner.name" class="header-bar-wrapper no-print">
           <div class="header-bar">
             <h1>Filings for {{petitioner.name}}</h1>
@@ -180,6 +183,7 @@
 
         <filing-nav v-bind:filings="filings"></filing-nav>
 
+        <!-- Cover letter & checkout sheet wrapper -->
         <table class="extra-pages">
           <tbody>
             <tr>
@@ -192,10 +196,11 @@
                     >Terms and Conditions.</a
                   >
                 </section>
-                <!-- Begin Extra Documents -->
 
+                <!-- Begin Cover Sheet -->
                 <section class="extra-documents-top" id="extra-documents">
-                  <!-- Clinic Checkout Sheet -->
+                  
+                  <!-- Client Cover Letter -->
                   <article class="page" id="clinic-checkout">
                     <div class="document-meta-data no-print">
                       <p class="document-meta-data__title">Cover Letter</p>
@@ -322,10 +327,7 @@
                     </div>
                   </article>
 
-                  <!-- End Clinic Checkout Sheet -->
-
                   <!-- Client Checkout Sheet -->
-
                   <article class="page" id="client-checkout">
                     <div class="document-meta-data no-print">
                       <p class="document-meta-data__title">Checkout Sheet</p>
@@ -461,10 +463,9 @@
                     </div>
                   </article>
 
-                  <!-- End Client Checkout Sheet -->
                 </section>
+                <!-- End Cover Sheet -->
 
-                <!-- End Extra Documents -->
               </td>
             </tr>
           </tbody>
@@ -474,12 +475,16 @@
             </tr>
           </tfoot>
         </table>
+        <!-- Cover letter & checkout sheet wrapper -->
 
+        <!-- Petition wrapper -->
         <table v-if="filings.length != 0" class="all-filings">
           <tbody>
             <tr>
               <td>
                 <section v-for="group in filings" v-bind:id="group.county">
+
+                  <!-- Generic petition heading info -->
                   <article
                     class="page"
                     v-for="filing in group.filings"
@@ -532,11 +537,11 @@
                       </div>
 
                       <h1 class="filing-title">{{filing.title}}</h1>
+                      <!-- End generic petition heading info -->
 
                       <!-- Begin Unique Portion of Filings -->
 
                       <!-- Notice of Appearance -->
-
                       <div class="filing-body" v-if="filing.type == 'NoA'">
                         <p class="indent">
                           <template v-if="proSeFromRole(settings.role)">
@@ -650,7 +655,6 @@
                       </div>
 
                       <!-- (Stipulated) Petiton To Expunge Non Conviction -->
-
                       <div
                         class="filing-body"
                         v-if="filing.type == 'ExNC' || filing.type == 'StipExNC'"
@@ -738,7 +742,6 @@
                       </div>
 
                       <!-- (Stipulated) Petiton To Expunge Non-Crime -->
-
                       <div
                         class="filing-body"
                         v-if="filing.type == 'ExNCrim' || filing.type == 'StipExNCrim'"
@@ -819,7 +822,6 @@
                       </div>
 
                       <!-- (Stipulated) Petiton To Seal Conviction -->
-
                       <div
                         class="filing-body"
                         v-if="filing.type == 'SC' || filing.type == 'StipSC'"
@@ -903,7 +905,6 @@
                       </div>
 
                       <!-- (Stipulated) Petiton To Seal DUI Conviction -->
-
                       <div
                         class="filing-body"
                         v-if="filing.type == 'SDui' || filing.type == 'StipSDui'"
@@ -986,8 +987,8 @@
                           as
                         </p>
                       </div>
-
                       <!-- End Unique Portion of Filings -->
+
                       <template v-if="filing.type != 'NoA'">
                         <div class="filing-body__response">
                           <p
@@ -1002,7 +1003,7 @@
                         </div>
                       </template>
 
-                      <!-- Begin Closings -->
+                      <!-- Begin generic footer -->
                       <template v-if="filing.type != 'NoA'">
                         <div class="filing-closing">
                             <p class="filing-closing__salutation">
@@ -1064,8 +1065,8 @@
                                 </div>
                             </div>
                     </template>
+                    <!-- End generic footer -->
 
-                      <!-- End Closings -->
                     </div>
                   </article>
 
@@ -1082,6 +1083,7 @@
             </tr>
           </tfoot>
         </table>
+        <!-- End petition wrapper -->
 
         <div v-if="settings.forVla" class="footer">
           <p class="footer__company">Vermont Legal Aid, Inc.</p>
@@ -1092,6 +1094,8 @@
           <p class="footer__phone">{{settings['footer2']}}</p>
         </div>
       </template>
+
+      <!-- else show default "no filings" display -->
       <template v-else>
         <div class="no-filings">
           <p>
@@ -1111,6 +1115,7 @@
       </template>
     </div>
     <!-- End Vue App -->
+    
     <script id="script" src="components.js"></script>
     <script id="script" src="filings.js"></script>
     <script id="script" src="csv.js"></script>

--- a/extensionDirectory/filings.html
+++ b/extensionDirectory/filings.html
@@ -151,7 +151,6 @@
             <h1>Filings for {{petitioner.name}}</h1>
             <div class="header-bar__controls">
               <span>Consolidate by county: </span>
-              <!-- TODO: can you consoliate NoA without Petitions? Or the other way around? May need logic to handle an overriding case... -->
               <label v-if="numDockets > 1">
                 <input type="checkbox" v-model="groupNoas"/>
                 NoA

--- a/extensionDirectory/filings.html
+++ b/extensionDirectory/filings.html
@@ -150,9 +150,14 @@
           <div class="header-bar">
             <h1>Filings for {{petitioner.name}}</h1>
             <div class="header-bar__controls">
-              <label v-if="numDockets > 1"
-                >Consolidate Petitions
+              <span>Consolidate: </span>
+              <label v-if="numDockets > 1">
                 <input type="checkbox" v-model="groupCounts" />
+                Petitions
+              </label>
+              <label v-if="numDockets > 1">
+                <input type="checkbox" v-model="groupNoas"/>
+                NoA
               </label>
               <button
                 v-on:click="printDocument"

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -179,6 +179,7 @@ var app = new Vue({
       counts: [],
     },
     groupCounts: false,
+    groupNoas: true,
     responses: {},
     countiesContact: {},
     popupHeadline: '',

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -440,10 +440,13 @@ var app = new Vue({
 
         // when the county changes, insert a NOA
         if (lastCounty != currCounty) {
-          var NoACounts = filings.filter((f) => f.county == currCounty);
+          var counts = filings
+            .filter((f) => f.county == currCounty)
+            .map((f) => f.counts)
+            .flat();
           var noticeOfAppearanceObject = this.createNoticeOfAppearanceFiling(
             currCounty,
-            NoACounts
+            counts
           );
           filingsWithNOAs.push(noticeOfAppearanceObject);
           lastCounty = currCounty;

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -275,7 +275,14 @@ var app = new Vue({
         });
       });
     },
-    groupCountsIntoFilings: function (counts, groupDockets = true) {
+
+    /**
+     * Creates the petition filings (including NOAs) from collected counts
+     *
+     * @param {Object} counts Count objects used to generate petitons
+     * @param {boolean} groupDockets Indicates whether to consolidate dockets into single petitons
+     */
+    createFilingsFromCounts: function (counts, groupDockets = true) {
       // get all counties that have counts associated with them
       var filingCounties = this.groupByCounty(counts);
 
@@ -737,11 +744,9 @@ var app = new Vue({
       };
     },
     filings: function () {
-      var shouldGroupCounts = true;
-      if (this.groupCounts !== undefined) {
-        shouldGroupCounts = this.groupCounts;
-      }
-      return this.groupCountsIntoFilings(this.saved.counts, shouldGroupCounts); //counts, groupCountsFromMultipleDockets=true
+      var shouldGroupCounts =
+        this.groupCounts !== undefined ? this.groupCounts : true;
+      return this.createFilingsFromCounts(this.saved.counts, shouldGroupCounts); //counts, groupCountsFromMultipleDockets=true
     },
     numCountsToExpungeOrSeal: function () {
       return this.saved.counts.filter((count) => count.filingType !== 'X')

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -371,8 +371,8 @@ var app = new Vue({
         );
 
         //iterate through the filing types needed for this county and push them into the array
-        for (var filingIndex in filingsForThisCounty) {
-          var filingType = filingsForThisCounty[filingIndex];
+        for (var i in filingsForThisCounty) {
+          var filingType = filingsForThisCounty[i];
 
           //if the filing is not one we're going to need a petition for, let's skip to the next filing type
           if (!this.isFileable(filingType)) continue;

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -353,8 +353,8 @@ var app = new Vue({
         );
 
         //iterate through the filing types needed for this county and push them into the array
-        for (var i in filingsForThisCounty) {
-          var filingType = filingsForThisCounty[i];
+        for (var filingIndex in filingsForThisCounty) {
+          var filingType = filingsForThisCounty[filingIndex];
 
           //if the filing is not one we're going to need a petition for, let's skip to the next filing type
           if (!this.isFileable(filingType)) continue;

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -337,8 +337,8 @@ var app = new Vue({
         }
 
         //iterate through the filing types needed for this county and push them into the array
-        for (var filingIndex in filingsForThisCounty) {
-          var filingType = filingsForThisCounty[filingIndex];
+        for (var i in filingsForThisCounty) {
+          var filingType = filingsForThisCounty[i];
 
           //if the filing is not one we're going to need a petition for, let's skip to the next filing type
           if (!this.isFileable(filingType)) continue;

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -188,6 +188,24 @@ var app = new Vue({
     stipDef: {},
   },
   watch: {
+    // Affects "consolidation" checkboxes in filings page header
+    // This watch ensures that "NoAs" checkbox IS checked when "Petitions" checkbox is checked
+    groupCounts: {
+      handler(value) {
+        if (value) {
+          this.groupNoas = true;
+        }
+      },
+    },
+    // Affects "consolidation" checkboxes in filings page header
+    // This watch ensures that "Petitions" checkbox IS NOT checked when unchecking "NoAs" checkbox
+    groupNoas: {
+      handler(value) {
+        if (!value) {
+          this.groupCounts = false;
+        }
+      },
+    },
     responses: {
       handler() {
         app.saveResponses();
@@ -388,7 +406,7 @@ var app = new Vue({
           }
         }
         // insert NOAs into filings
-        const filingsWithNOAs = this.groupCounts
+        const filingsWithNOAs = this.groupNoas
           ? this.insertNOAsForEachCounty(allFilingsForThisCountyObject)
           : this.insertNOAsForEachDocket(allFilingsForThisCountyObject);
 

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -388,13 +388,9 @@ var app = new Vue({
           }
         }
         // insert NOAs into filings
-        const filingsWithNOAs = this.insertNOAsBeforeCounties(
-          allFilingsForThisCountyObject
-        );
-        // const filingsWithNOAs = this.insertIndividualNOAs(
-        //   allFilingsForThisCountyObject,
-        //   countyName
-        // );
+        const filingsWithNOAs = this.groupCounts
+          ? this.insertNOAsForEachCounty(allFilingsForThisCountyObject)
+          : this.insertNOAsForEachDocket(allFilingsForThisCountyObject);
 
         //add all filings for this county to the returned filing object.
         groupedFilings.push({
@@ -433,7 +429,7 @@ var app = new Vue({
      * @param {object} filings      An array of filing objects that needs some NOAs added to it
      * @param {string} countyName   The name of the county is needed by the fn() that creates the NOA
      */
-    insertNOAsBeforeCounties: function (filings) {
+    insertNOAsForEachCounty: function (filings) {
       let lastCounty = '';
       let filingsWithNOAs = [];
 
@@ -462,10 +458,9 @@ var app = new Vue({
     /*
      * Inserts an NOA each time the docket changes in the array of filings.
      * @param {object} filings      An array of filing objects that needs some NOAs added to it
-     * @param {string} countyName   The name of the county is needed by the fn() that creates the NOA
      * @TODO: simplify this function
      */
-    insertIndividualNOAs: function (filings, countyName) {
+    insertNOAsForEachDocket: function (filings) {
       let lastDocketNum = '';
       let filingsWithNOAs = [];
       for (var i = 0; i < filings.length; i++) {
@@ -493,7 +488,7 @@ var app = new Vue({
                 })
                 .flat();
               const noticeOfAppearanceObject = this.createNoticeOfAppearanceFiling(
-                countyName,
+                thisFiling.county,
                 docketCounts
               );
               lastDocketNum = currDocketNum;

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -352,16 +352,6 @@ var app = new Vue({
           maxDocketsPerNoA
         );
 
-        // iterate through our array of segmented count arrays to create all of the NoAs needed.
-        // for (var i in allEligibleCountsForThisCountySegmented) {
-        //   var NoACounts = allEligibleCountsForThisCountySegmented[i];
-        //   var noticeOfAppearanceObject = this.createNoticeOfAppearanceFiling(
-        //     countyName,
-        //     NoACounts
-        //   );
-        //   allFilingsForThisCountyObject.push(noticeOfAppearanceObject);
-        // }
-
         //iterate through the filing types needed for this county and push them into the array
         for (var i in filingsForThisCounty) {
           var filingType = filingsForThisCounty[i];
@@ -398,10 +388,13 @@ var app = new Vue({
           }
         }
         // insert NOAs into filings
-        const filingsWithNOAs = this.insertIndividualNOAs(
-          allFilingsForThisCountyObject,
-          countyName
+        const filingsWithNOAs = this.insertNOAsBeforeCounties(
+          allFilingsForThisCountyObject
         );
+        // const filingsWithNOAs = this.insertIndividualNOAs(
+        //   allFilingsForThisCountyObject,
+        //   countyName
+        // );
 
         //add all filings for this county to the returned filing object.
         groupedFilings.push({
@@ -436,12 +429,43 @@ var app = new Vue({
     },
 
     /*
-     * Inserts one NOA for each unique docket filing in provided array.
+     * Inserts an NOA each time the county changes in the array of filings.
      * @param {object} filings      An array of filing objects that needs some NOAs added to it
      * @param {string} countyName   The name of the county is needed by the fn() that creates the NOA
      */
+    insertNOAsBeforeCounties: function (filings) {
+      let lastCounty = '';
+      let filingsWithNOAs = [];
+
+      // loop over all the filings
+      for (var i = 0; i < filings.length; i++) {
+        const thisFiling = filings[i];
+        const currCounty = thisFiling.county;
+
+        // when the county changes, insert a NOA
+        if (lastCounty != currCounty) {
+          var NoACounts = filings.filter((f) => f.county == currCounty);
+          var noticeOfAppearanceObject = this.createNoticeOfAppearanceFiling(
+            currCounty,
+            NoACounts
+          );
+          filingsWithNOAs.push(noticeOfAppearanceObject);
+          lastCounty = currCounty;
+        }
+
+        // always add the filings
+        filingsWithNOAs.push(thisFiling);
+      }
+      return filingsWithNOAs;
+    },
+
+    /*
+     * Inserts an NOA each time the docket changes in the array of filings.
+     * @param {object} filings      An array of filing objects that needs some NOAs added to it
+     * @param {string} countyName   The name of the county is needed by the fn() that creates the NOA
+     * @TODO: simplify this function
+     */
     insertIndividualNOAs: function (filings, countyName) {
-      // optinally add a NoA for every single docket
       let lastDocketNum = '';
       let filingsWithNOAs = [];
       for (var i = 0; i < filings.length; i++) {

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -179,7 +179,7 @@ var app = new Vue({
       counts: [],
     },
     groupCounts: false,
-    groupNoas: true,
+    groupNoas: false,
     responses: {},
     countiesContact: {},
     popupHeadline: '',


### PR DESCRIPTION
When there is one NoA for each docket, it gets pretty hard to visually skim the nav list. This bundles things up a little.

|before|after|
|--------|-------|
|![image](https://user-images.githubusercontent.com/1809882/98005073-ad18af80-1dbe-11eb-9851-1c8235e24932.png)|![image](https://user-images.githubusercontent.com/1809882/98005014-95d9c200-1dbe-11eb-8205-28437fbf7511.png)|