### PR TITLE
Toggle checkbox label too

### DIFF
--- a/extensionDirectory/filings.html
+++ b/extensionDirectory/filings.html
@@ -150,15 +150,17 @@
           <div class="header-bar">
             <h1>Filings for {{petitioner.name}}</h1>
             <div class="header-bar__controls">
-              <span>Consolidate by county: </span>
-              <label v-if="numDockets > 1">
-                <input type="checkbox" v-model="groupNoas"/>
-                NoA
-              </label>
-              <label v-if="numDockets > 1">
-                <input type="checkbox" v-model="groupCounts" />
-                Petitions
-              </label>
+              <div v-if="numDockets > 1">
+                <span>Consolidate by county: </span>
+                <label>
+                  <input type="checkbox" v-model="groupNoas"/>
+                  NoA
+                </label>
+                <label>
+                  <input type="checkbox" v-model="groupCounts" />
+                  Petitions
+                </label>
+              </div>
               <button
                 v-on:click="printDocument"
                 class="btn btn-primary no-print"

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -909,6 +909,7 @@ var app = new Vue({
           count.filingType === 'SDui' || count.filingType === 'StipSDui'
       );
     },
+    /* Checkes the computed `filings` property to see how many unique dockets there are */
     numDockets: function () {
       const dockets = this.filings
         .map((f) =>

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -910,14 +910,20 @@ var app = new Vue({
       );
     },
     numDockets: function () {
-      var numDockets = this.saved.counts.filter((e, i) => {
-        return (
-          this.saved.counts.findIndex((x) => {
-            return x.docketNum == e.docketNum && x.county == e.county;
-          }) == i
-        );
-      });
-      return numDockets.length;
+      const dockets = this.filings
+        .map((f) =>
+          f.filings
+            .map((f2) => f2.docketNums.map((d) => d.string).flat())
+            .flat()
+        )
+        .flat();
+      const uniqueDockets = dockets.reduce((acc, n) => {
+        if (!acc.includes(n)) {
+          acc.push(n);
+        }
+        return acc;
+      }, []);
+      return uniqueDockets.length;
     },
     csvFilename: function () {
       var date = new Date();


### PR DESCRIPTION
Previously the label reading "Consolidate by county" was not being hidden when there was only one docket being filed. This PR makes 2 changes:

- [x] Hide both the checkboxes and the labels
- [x] Make the `numDockets` dynamic so that conditional view elements will change when the petitions change 

![image](https://user-images.githubusercontent.com/1809882/98271346-dd4a8480-1f5d-11eb-8223-be5b07371e76.png)
