### PR TITLE
Bug: odyssey name format

### DIFF
--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -668,6 +668,10 @@ var app = new Vue({
       );
       return this.makeFilingObject(countsOnThisFiling, filingType, county);
     },
+    /*
+     * Creates a filing object from data provided.
+     * NOTE: will fail without explaination on civil violations b/c this presumes `counts` is a non-empty array
+     */
     makeFilingObject: function (counts, filingType, county) {
       var countsOnThisFiling = counts;
       var numCounts = countsOnThisFiling.length;

--- a/extensionDirectory/popup.js
+++ b/extensionDirectory/popup.js
@@ -200,7 +200,11 @@ function getOdysseyPetitionerInfo(docketData) {
       }
     });
 
-    currentDocket.defName = partyInfo.find('td:first-of-type').html().trim();
+    // get name from page and reformat it if necessary
+    // Note: it would be more durable to parse the fname, lname and any titles (Jr, III, etc) - possible refactor.
+    const rawName = partyInfo.find('td:first-of-type').html().trim();
+    currentDocket.defName = formatPetitionersName(rawName);
+
     currentDocket.defDOB = partyInfo
       .find("[label='DOB:'] .roa-value")
       .text()
@@ -212,6 +216,21 @@ function getOdysseyPetitionerInfo(docketData) {
     return currentDocket;
   } catch (err) {
     alert('Petitioner Info Error: ' + err);
+  }
+}
+
+/**
+ * A helper method to format names as "Firstname Lastname"
+ * @param {string} fullTextName A person's name which may, or may not, be formatted as "Lastname, Firstname"
+ */
+function formatPetitionersName(fullTextName) {
+  const commaIndex = fullTextName.indexOf(',');
+  if (commaIndex == -1) {
+    return fullTextName;
+  } else {
+    const lname = fullTextName.substring(0, commaIndex);
+    const fname = fullTextName.substring(commaIndex + 1);
+    return `${fname.trim()} ${lname.trim()}`;
   }
 }
 


### PR DESCRIPTION
Added a simple filter that breaks a string on a `,`, parses the before & after pieces, and concatenates them into a "Firstname Lastname" format. 

Not 100% sure how all name formats would be handled though...

| before | <img src="https://user-images.githubusercontent.com/1809882/98375632-5efaea80-2010-11eb-8343-250dafdf62d5.png" width=500>|
|-------|----|
|after|<img src="https://user-images.githubusercontent.com/1809882/98375317-f6137280-200f-11eb-9209-8f38c012cc72.png" width=500>|
