### PR TITLE
Bug: failing to parse dockets w/ 10+ counts

### DIFF
--- a/extensionDirectory/popup.js
+++ b/extensionDirectory/popup.js
@@ -347,7 +347,10 @@ function getOdysseyCountInfo(docket, docketUrl) {
         .find('.roa-event-content > div > div > div:first')
         .text()
         .trim();
-      const countNum = parseInt(countText.substr(0, 1), 10);
+
+      /* TODO: handle the case where the count number cannot be parsed */
+      const parsedNum = countText.match(/^\d+/);
+      const countNum = parsedNum.length == 1 ? parseInt(parsedNum[0], 10) : 0;
       let decision = jqDisp
         .find('.roa-event-content > div > div > div:nth-child(2)')
         .text()


### PR DESCRIPTION
Fixes the bug for parsing the number of counts.

Previously we were only looking for one digit when parsing count numbers. In dockets where there were more than 9 counts, this was causing a parse error that caused the extension to silently fail.