### PR TITLE
Bug: Filter out NOA filings from cover sheet count

### DIFF
--- a/extensionDirectory/filings.html
+++ b/extensionDirectory/filings.html
@@ -281,7 +281,7 @@
                             v-bind:id="group.county"
                           >
                             <li>
-                              {{group.filings.length - 1}}
+                              {{group.filings | numWithoutNOAs}}
                               <span v-if="group.filings.length > 2"
                                 >petitions</span
                               ><span v-else>petition</span> for {{group.county}}

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -860,6 +860,8 @@ var app = new Vue({
         address: this.nl2br(this.saved.defAddress),
       };
     },
+
+    /* "Filings" include the Notice of Appearance (NoA) forms */
     filings: function () {
       var shouldGroupCounts =
         this.groupCounts !== undefined ? this.groupCounts : true;
@@ -919,7 +921,7 @@ var app = new Vue({
           count.filingType === 'SDui' || count.filingType === 'StipSDui'
       );
     },
-    /* Checkes the computed `filings` property to see how many unique dockets there are */
+    /* Checks the computed `filings` property to see how many unique dockets there are */
     numDockets: function () {
       const dockets = this.filings
         .map((f) =>
@@ -1006,6 +1008,14 @@ var app = new Vue({
     toCountyCode: function (value) {
       if (!value) return '';
       return countyCodeFromCounty(value);
+    },
+
+    /** Takes an array of filings and figures out how many there are after omitting the NOAs
+     * @param array   An array of filings
+     * @return int    The number of filings that are not NOAs
+     */
+    numWithoutNOAs: function (filings) {
+      return filings.filter((f) => f.type != 'NoA').length;
     },
   },
 });

--- a/extensionDirectory/popup.js
+++ b/extensionDirectory/popup.js
@@ -347,7 +347,10 @@ function getOdysseyCountInfo(docket, docketUrl) {
         .find('.roa-event-content > div > div > div:first')
         .text()
         .trim();
-      const countNum = parseInt(countText.substr(0, 1), 10);
+
+      /* TODO: handle the case where the count number cannot be parsed */
+      const parsedNum = countText.match(/^\d+/);
+      const countNum = parsedNum.length == 1 ? parseInt(parsedNum[0], 10) : 0;
       let decision = jqDisp
         .find('.roa-event-content > div > div > div:nth-child(2)')
         .text()


### PR DESCRIPTION
Previously the cover letter was including the NOAs as counts when it told clients how many petitions were being created for each county:

| Before | After |
|--------|------|
|<img src="https://user-images.githubusercontent.com/1809882/99595292-751a8a80-29c2-11eb-9792-50fd1d6ef6c3.png" width=350 border=1/>|<img src="https://user-images.githubusercontent.com/1809882/102381386-20edd080-3f97-11eb-82fd-f0d0fa7b21e3.png" width=350 border=1/>|

This PR creates a filter that takes an array of filings, filters out the NOAs, and returns the remaining total. This total should always reflect the number of petitions shown on the checkout sheet.