### PR TITLE
City/Date blanks

### DIFF
--- a/extensionDirectory/components.js
+++ b/extensionDirectory/components.js
@@ -106,7 +106,12 @@ Vue.component('filing-footer', {
 
 Vue.component('filing-dated-city', {
   template: `
-    <p class="filing-dated-city indent">Dated in <span class="fill-in">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>, this <span class="fill-in">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span> day of <span class="fill-in">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>, 20<span class="fill-in">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>.</p>
+    <p class="filing-dated-city indent">
+      Dated in the city of <span class="fill-in quarter-width"></span>, 
+      on the day of <span class="fill-in digit-width"></span>, 
+      in the month of <span class="fill-in word-width"></span>,<br/>
+      in the year 20<span class="fill-in digit-width"></span>.
+    </p>
   `,
 });
 

--- a/extensionDirectory/filings.css
+++ b/extensionDirectory/filings.css
@@ -394,11 +394,25 @@ p.filing-dated-city {
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
 }
-/* Use this with a span full of non-breaking spaces to give it a solid fill-in underline */
+
+/* Use "fill-in" for a solid underline where people need to fill in 
+ * information. Use one of the cascading modifiers to get the desired width. 
+ */
 .fill-in {
-  opacity: 1;
-  position: relative;
   border-bottom: 1.5px solid #000;
+  display: inline-block;
+}
+.fill-in.half-width {
+  width: 360px;
+}
+.fill-in.quarter-width {
+  width: 180px;
+}
+.fill-in.word-width {
+  width: 100px;
+}
+.fill-in.digit-width {
+  width: 40px;
 }
 
 /* CHeckout sheet */


### PR DESCRIPTION
This updates the blanks in the petitions for the city and date as seen below.  We are changing these lines to look like:

```Dated in the city of _____________, on the day of _______, in the month of _________, in the year 20___```

<blockquote>
<img src="https://user-images.githubusercontent.com/1809882/101831106-84917d00-3b03-11eb-8f61-3674c2c74852.png" width="450px"/>
</blockquote>