### PR TITLE
BUG: failure when parsing page with multiple dockets

### DIFF
--- a/extensionDirectory/popup.js
+++ b/extensionDirectory/popup.js
@@ -450,9 +450,6 @@ function getVTCOPetitionerInfo(data) {
     addressArray[i] = addressArray[i].trim();
   }
 
-  //get docket Num
-  docketSheetNum = rawData.match(/([Docket No.\s+])(\d.*?cr)/)[0].trim();
-
   //create all counts object
   parsedData = {
     defName: defName,
@@ -551,6 +548,11 @@ function processCountLine1(countLine1, countNum, rawData) {
     }
   }
 
+  // get docketNum & docketSheetNum
+  const docketCounty = countLine1Array[2];
+  const docketNum = countLine1Array[1];
+  const docketSheetNum = `${docketNum} ${docketCounty}`;
+
   var uid =
     docketSheetNum +
     countLine1Array[0] +
@@ -560,13 +562,14 @@ function processCountLine1(countLine1, countNum, rawData) {
 
   offenseDisposition = beautifyDisposition(disposition);
   dispositionDate = countLine1Array[felMisLocation + 1];
+
   //Create count object with all count line 1 items
   countObject = {
     guid: guid(),
     uid: uid,
     countNum: countLine1Array[0],
-    docketNum: countLine1Array[1],
-    docketCounty: countLine1Array[2],
+    docketNum: docketNum,
+    docketCounty: docketCounty,
     county: countyNameFromCountyCode(countLine1Array[2]),
     titleNum: countLine1Array[4],
     sectionNum: offenseSection,


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/1809882/103800540-8a9f4e80-501a-11eb-868c-8c0f4652e41c.png" width=500/>

**SAMPLE**: [Sample docket #2](http://htmlpreview.github.io/?https://github.com/codeforbtv/expunge-vt/blob/master/sampleDocketHTML/sample2.html) has an example of a page where two cases with different docket numbers are presented together. 

**PROBLEM**: When parsing pages like the sample above, the `docketNum` and `docketSheetNum` did not match for any cases after the first. This caused an error downstream when trying to render the petitions.

**SOLUTION**: The fix was to change which docket number was parsed. Instead of using the docket number at the top of the page for all counts, the docket number on the count row is used. 

**NOTE:** This fix is specific to VT Courts Online


