### PR TITLE
Add PNG loader to esbuild.

### DIFF
--- a/extensionDirectory/build.js
+++ b/extensionDirectory/build.js
@@ -11,6 +11,9 @@ esbuild.build({
           src: './static',
           dest: './build'
         })],
+    loader: {
+        '.png': 'file'
+    },
     define: {
         "process.env.NODE_ENV": JSON.stringify("development"),
     },

--- a/extensionDirectory/components/popup.vue
+++ b/extensionDirectory/components/popup.vue
@@ -1291,11 +1291,13 @@ export default {
     <div id="logoDivCover">
       <img
         id="code4btv"
+        src="@/images/code4BTV-logo-300-300.png"
         alt="Home"
         class="logos"
       />
       <img
         id="legal-aid"
+        src="@/images/VLA_logo-200-97px.png"
         alt="Home"
         class="logos"
       />

--- a/extensionDirectory/jsconfig.json
+++ b/extensionDirectory/jsconfig.json
@@ -1,0 +1,9 @@
+{
+    "allowJs": true,
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["./*"]
+        }
+    }
+}


### PR DESCRIPTION
This request proposes adding a loader within the esbuild configuration file, for loading the static assets (two PNG files) present on the extension landing:

![Expunge_VT_PNG_Loader](https://user-images.githubusercontent.com/112483617/210655424-1bb276e9-2b6e-404d-b587-79ee0894f6fc.PNG)

Additionally, directory paths from the root directory are aliased by adding a `jsconfig.json` file with the proposed configurations.