### PR TITLE
Kylefork2023 off benfork2022 off jakefork2021

### DIFF
--- a/extensionDirectory/build.js
+++ b/extensionDirectory/build.js
@@ -30,6 +30,27 @@ esbuild.build({
 });
 
 esbuild.build({
+    entryPoints: ['filings.js'],
+    bundle: true,
+    outfile: 'build/filings.js',
+    plugins: [vuePlugin()],
+    define: {
+        "process.env.NODE_ENV": JSON.stringify("development"),
+    },
+});
+
+esbuild.build({
+    entryPoints: ['saveFile.js'],
+    bundle: true,
+    outfile: 'build/saveFile.js',
+    //plugins: [vuePlugin()],
+    define: {
+        "process.env.NODE_ENV": JSON.stringify("development"),
+    },
+});
+
+
+esbuild.build({
     entryPoints: ['background.js'],
     bundle: true,
     outfile: 'build/background.js',

--- a/extensionDirectory/components/popup.vue
+++ b/extensionDirectory/components/popup.vue
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import moment from 'moment';
 import Gumshoe from 'gumshoejs'
 import SmoothScroll from 'smooth-scroll';
+import Vue as * from 'vue';
 
 import pillsRow from './pills-row.vue';
 import checkoutOffenseRow from './checkout-offense-row.vue'
@@ -1291,13 +1292,13 @@ export default {
     <div id="logoDivCover">
       <img
         id="code4btv"
-        src="@/images/code4BTV-logo-300-300.png"
+        src="/images/code4BTV-logo-300-300.png"
         alt="Home"
         class="logos"
       />
       <img
         id="legal-aid"
-        src="@/images/VLA_logo-200-97px.png"
+        src="/images/VLA_logo-200-97px.png"
         alt="Home"
         class="logos"
       />

--- a/extensionDirectory/filings.js
+++ b/extensionDirectory/filings.js
@@ -1,5 +1,5 @@
 import './filings.css';
-import { createApp } from 'vue/dist/vue.esm-bundler.js';
+import { createApp } from 'vue';
 import $ from 'jquery';
 import moment from 'moment';
 import Gumshoe from 'gumshoejs'

--- a/extensionDirectory/index.js
+++ b/extensionDirectory/index.js
@@ -1,6 +1,7 @@
 const jQuery = require('jquery'); 
 window.$ = jQuery; 
 window.jQuery = jQuery;
+const Vue = require('vue');
 require('bootstrap');
 require('bootstrap/dist/css/bootstrap.min.css');
 require('bootstrap4-toggle');

--- a/extensionDirectory/yarn.lock
+++ b/extensionDirectory/yarn.lock
@@ -298,11 +298,6 @@
   "resolved" "https://registry.npmjs.org/esbuild-copy-static-files/-/esbuild-copy-static-files-0.1.0.tgz"
   "version" "0.1.0"
 
-"esbuild-darwin-arm64@0.14.42":
-  "integrity" "sha512-bU2tHRqTPOaoH/4m0zYHbFWpiYDmaA0gt90/3BMEFaM0PqVK/a6MA2V/ypV5PO0v8QxN6gH5hBPY4YJ2lopXgA=="
-  "resolved" "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.42.tgz"
-  "version" "0.14.42"
-
 "esbuild-plugin-vue3@^0.3.0":
   "integrity" "sha512-b8ypadGLuxJ02cPUXn/2yKhwMsEQ/JZMO3lN871X12ZKigXymZStBCexVI4C7lr7lguxa+IpU94pRQ/BtInMsQ=="
   "resolved" "https://registry.npmjs.org/esbuild-plugin-vue3/-/esbuild-plugin-vue3-0.3.0.tgz"
@@ -311,6 +306,11 @@
     "@vue/compiler-core" "^3.2.22"
     "@vue/compiler-sfc" "^3.2.22"
     "esbuild" "^0.12.22"
+
+"esbuild-windows-64@0.14.42":
+  "integrity" "sha512-j3cdK+Y3+a5H0wHKmLGTJcq0+/2mMBHPWkItR3vytp/aUGD/ua/t2BLdfBIzbNN9nLCRL9sywCRpOpFMx3CxzA=="
+  "resolved" "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.42.tgz"
+  "version" "0.14.42"
 
 "esbuild@^0.12.22":
   "integrity" "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g=="


### PR DESCRIPTION
* Had issues with png file loader so we relied on Root absolute path URLs
* Added entry files for additional JS files in `build.js`, but this can probably be refactored into the array of `EntryPoints`
* found an elligible import for Vue

    ```js
    import Vue as * from 'vue';
    ```

However, still getting the error:

```log
index.js:49444 Uncaught ReferenceError: Vue is not defined
    at Proxy.addAndOpenManagePage (index.js:49444:15)
```

Might be worth going back to original `filings.js` and updating the imports there
