### PR TITLE
Chrome Extension Manifest V3 changes and dependency management.

### DIFF
--- a/extensionDirectory/build.js
+++ b/extensionDirectory/build.js
@@ -3,58 +3,22 @@ const esbuild = require('esbuild');
 const copyStaticFiles = require('esbuild-copy-static-files')
 
 esbuild.build({
-    entryPoints: ['index.js'],
+    entryPoints: ['background.js', 'filings.js', 'index.js', 'payload.js', 'saveFile.js'],
     bundle: true,
-    outfile: 'build/index.js',
+    outdir: 'build/',
     plugins: [vuePlugin(),
         copyStaticFiles({
           src: './static',
           dest: './build'
         })],
     loader: {
-        '.png': 'file'
-    },
-    define: {
-        "process.env.NODE_ENV": JSON.stringify("development"),
-    },
-});
-
-esbuild.build({
-    entryPoints: ['payload.js'],
-    bundle: true,
-    outfile: 'build/payload.js',
-    plugins: [vuePlugin()],
-    define: {
-        "process.env.NODE_ENV": JSON.stringify("development"),
-    },
-});
-
-esbuild.build({
-    entryPoints: ['filings.js'],
-    bundle: true,
-    outfile: 'build/filings.js',
-    plugins: [vuePlugin()],
-    define: {
-        "process.env.NODE_ENV": JSON.stringify("development"),
-    },
-});
-
-esbuild.build({
-    entryPoints: ['saveFile.js'],
-    bundle: true,
-    outfile: 'build/saveFile.js',
-    //plugins: [vuePlugin()],
-    define: {
-        "process.env.NODE_ENV": JSON.stringify("development"),
-    },
-});
-
-
-esbuild.build({
-    entryPoints: ['background.js'],
-    bundle: true,
-    outfile: 'build/background.js',
-    //plugins: [vuePlugin()],
+            '.eot': 'dataurl',
+            '.png': 'file',
+            '.ttf': 'dataurl',
+            '.svg': 'dataurl',
+            '.woff': 'dataurl',
+            '.woff2': 'dataurl',
+        },
     define: {
         "process.env.NODE_ENV": JSON.stringify("development"),
     },

--- a/extensionDirectory/components/pills-row.vue
+++ b/extensionDirectory/components/pills-row.vue
@@ -1,4 +1,6 @@
 <script>
+import moment from 'moment';
+
 export default {
   props: ["count", "dob"],
   methods: {

--- a/extensionDirectory/components/popup.vue
+++ b/extensionDirectory/components/popup.vue
@@ -13,6 +13,8 @@ import filingFooter from './filing-footer.vue'
 import filingNav from './filing-nav.vue'
 import filingTypeHeading from './filing-type-heading.vue'
 
+import { devLog, getError } from '../utils';
+
 const maxCountsOnNoA = 10;
 // Vue.config.devtools = true;
 
@@ -27,23 +29,6 @@ $(document).on('keydown', function (e) {
     app.printDocument();
   }
 });
-
-/**
- * Replaces console.log() statements with a wrapper that prevents the extension from logging
- * to the console unless it was installed by a developer. This will keep the console clean; a
- * practice recommended for chrome extensions.
- *
- * @param {any} data Data to log to the console
- * @todo find a way to make this reusuable, then delete the duplicate fn() in popup.js
- */
-function devLog(data) {
-  // see https://developer.chrome.com/extensions/management#method-getSelf
-  chrome.management.getSelf(function (self) {
-    if (self.installType == 'development') {
-      console.log(data);
-    }
-  });
-}
 
 function initAfterVue() {
   //sets intital height of all text areas to show all text.
@@ -80,7 +65,7 @@ function initSmoothScroll() {
   });
 }
 
-function detectChangesInChromeStorage() {
+function detectChangesInChromeStorage(app) {
   chrome.storage.onChanged.addListener(function (changes, namespace) {
     var countsChange = changes['counts'];
     var responsesChange = changes['responses'];
@@ -174,31 +159,6 @@ function countyCodeFromCounty(county) {
     Windsor: 'Wrcr',
   };
   return countyCodes[county];
-}
-
-function getError() {
-  return 'TOOD: getError should work :('; // TODO: The code below explodes, so just no-op for now
-  // return new Error().stack
-  //   .split('\n')[1]
-  //   .split('filings.js')[1]
-  //   .replace(')', '')
-}
-
-/**
- * Replaces console.log() statements with a wrapper that prevents the extension from logging
- * to the console unless it was installed by a developer. This will keep the console clean; a
- * practice recommended for chrome extensions.
- *
- * @param {any} data Data to log to the console
- * @todo find a way to make this reusuable, then delete the duplicate fn() in popup.js
- */
-function devLog(data) {
-  // see https://developer.chrome.com/extensions/management#method-getSelf
-  chrome.management.getSelf(function (self) {
-    if (self.installType == 'development') {
-      console.log(data);
-    }
-  });
 }
 
 export default {
@@ -344,7 +304,7 @@ export default {
   mounted() {
     devLog('App mounted!');
     this.loadAll();
-    detectChangesInChromeStorage();
+    detectChangesInChromeStorage(this);
 
     //This is to make sure dynamically created table are unique across tab in order to avoid errors
     this.uniqueId = this._uid;
@@ -370,6 +330,7 @@ export default {
       });
     },
     loadAll: function (callback) {
+      var self = this;
       if (callback === undefined) {
         callback = function () { };
       }
@@ -394,11 +355,11 @@ export default {
         devLog(JSON.stringify(result));
         if (result.counts !== undefined) {
           devLog(result.counts);
-          this.saved = result.counts;
+          self.saved = result.counts;
         }
 
         if (result.responses !== undefined) {
-          this.responses = result.responses;
+          self.responses = result.responses;
         }
 
         callback();
@@ -1093,6 +1054,38 @@ export default {
         return false;
       }
     },
+    stringAgeInYearsAtDate: function (date, dob) {
+      if (!date) return '';
+      if (!dob) return '';
+      let fromTime = moment(date).diff(moment(dob));
+      let duration = moment.duration(fromTime);
+      return (duration.asDays() / 365.25).toFixed(0) + ' yo';
+    },
+    sinceNow: function (value) {
+      if (!value) return '';
+
+      let fromTime = moment(value).diff(moment(), 'milliseconds');
+      let duration = moment.duration(fromTime);
+      let years = duration.years() / -1;
+      let months = duration.months() / -1;
+      let days = duration.days() / -1;
+      if (years > 0) {
+        var Ys = years == 1 ? years + 'y ' : years + 'y ';
+        var Ms = months == 1 ? months + 'm ' : months + 'm ';
+        return Ys + Ms;
+      } else {
+        if (months > 0) return months == 1 ? months + 'm ' : months + 'm ';
+        else return days == 1 ? days + 'd ' : days + 'd ';
+      }
+    },
+    dateFormatSimple: function (value) {
+      if (!value) return '';
+      return moment(value).format('MM/DD/YYYY');
+    },
+    toCountyCode: function (value) {
+      if (!value) return '';
+      return countyCodeFromCounty(value);
+    },
   },
   computed: {
     petitioner: function () {
@@ -1229,31 +1222,6 @@ export default {
       value = value.toString();
       return value.charAt(0).toLowerCase() + value.slice(1);
     },
-    sinceNow: function (value) {
-      if (!value) return '';
-
-      let fromTime = moment(value).diff(moment(), 'milliseconds');
-      let duration = moment.duration(fromTime);
-      let years = duration.years() / -1;
-      let months = duration.months() / -1;
-      let days = duration.days() / -1;
-      if (years > 0) {
-        var Ys = years == 1 ? years + 'y ' : years + 'y ';
-        var Ms = months == 1 ? months + 'm ' : months + 'm ';
-        return Ys + Ms;
-      } else {
-        if (months > 0) return months == 1 ? months + 'm ' : months + 'm ';
-        else return days == 1 ? days + 'd ' : days + 'd ';
-      }
-    },
-    dateFormatSimple: function (value) {
-      if (!value) return '';
-      return moment(value).format('MM/DD/YYYY');
-    },
-    toCountyCode: function (value) {
-      if (!value) return '';
-      return countyCodeFromCounty(value);
-    },
 
     /** Takes an array of filings and figures out how many there are after omitting the NOAs
      * @param array   An array of filings
@@ -1287,14 +1255,7 @@ export default {
         2
       );
       return surcharge;
-    },
-    stringAgeInYearsAtDate: function (date, dob) {
-      if (!date) return '';
-      if (!dob) return '';
-      let fromTime = moment(date).diff(moment(dob));
-      let duration = moment.duration(fromTime);
-      return (duration.asDays() / 365.25).toFixed(0) + ' yo';
-    },
+    }
   },
 }
 </script>
@@ -1416,10 +1377,12 @@ export default {
           Clear All
         </button>
         <img
+          src="/images/code4BTV-logo-300-300.png"
           alt="Home"
           class="logos"
         />
         <img
+          src="/images/VLA_logo-200-97px.png"
           alt="Home"
           class="logos"
         />

--- a/extensionDirectory/components/popup.vue
+++ b/extensionDirectory/components/popup.vue
@@ -3,7 +3,7 @@ import $ from 'jquery';
 import moment from 'moment';
 import Gumshoe from 'gumshoejs'
 import SmoothScroll from 'smooth-scroll';
-import Vue as * from 'vue';
+// import Vue as * from 'vue';
 
 import pillsRow from './pills-row.vue';
 import checkoutOffenseRow from './checkout-offense-row.vue'
@@ -565,7 +565,7 @@ export default {
           filingsWithNOAs.push(noa);
 
           if (this.responses[noa.id + '-feeForm'] === undefined) {
-            Vue.set(this.responses, noa.id + '-feeForm', false);
+            this.responses[noa.id + '-feeForm'] = false;
           } else if (this.responses[noa.id + '-feeForm']) {
             const feeFiling = this.createFeeFiling(
               thisFiling.county,
@@ -624,7 +624,7 @@ export default {
           filingsWithNOAs.push(noa);
 
           if (this.responses[noa.id + '-feeForm'] === undefined) {
-            Vue.set(this.responses, noa.id + '-feeForm', false);
+            this.responses[noa.id + '-feeForm'] = false;
           } else if (this.responses[noa.id + '-feeForm']) {
             const feeFiling = this.createFeeFiling(
               thisFiling.county,
@@ -649,7 +649,7 @@ export default {
 
     createResponseObjectForFiling: function (id) {
       if (this.responses[id] === undefined) {
-        Vue.set(this.responses, id, '');
+        this.responses[id] = '';
       }
     },
 
@@ -918,7 +918,7 @@ export default {
         (tabs) => {
           let index = tabs[0].index;
           chrome.tabs.create({
-            url: chrome.extension.getURL('./filings.html'),
+            url: chrome.runtime.getURL('./filings.html'),
             index: index + 1,
           });
         }
@@ -927,7 +927,7 @@ export default {
     addAndOpenManagePage: function () {
       if (this.saved.counts.length == 0) {
         this.newCount();
-        Vue.set(this.saved, 'defName', 'New Petitioner');
+        this.saved['defName'] = 'New Petitioner';
       }
       this.openManagePage();
     },
@@ -940,7 +940,7 @@ export default {
         (tabs) => {
           let index = tabs[0].index;
           chrome.tabs.create({
-            url: chrome.extension.getURL('./manage-counts.html'),
+            url: chrome.runtime.getURL('./manage-counts.html'),
             index: index + 1,
           });
         }
@@ -950,7 +950,13 @@ export default {
       // TODO: consider using content_scripts instead to avoid loading payload.js every time the
       // 'Add From Page' button is clicked.
       // see: https://stackoverflow.com/a/42989406/263900
-      chrome.tabs.executeScript(null, { file: 'payload.js' });
+      chrome.tabs.query({active: true, currentWindow: true}).then(([tab]) => {
+        chrome.scripting.executeScript(
+        {
+          target: {tabId: tab.id},
+          files: ['payload.js']
+        });
+      })
     },
     loadCaseFile: async function () {
       var query = { active: true, currentWindow: true };
@@ -976,7 +982,13 @@ export default {
       chrome.extension.isAllowedFileSchemeAccess(function (isAllowedAccess) {
         if (isAllowedAccess) {
           // alert for a quick demonstration, please create your own user-friendly UI
-          chrome.tabs.executeScript(null, { file: 'payload.js' });
+          chrome.tabs.query({active: true, currentWindow: true}).then(([tab]) => {
+            chrome.scripting.executeScript(
+            {
+              target: {tabId: tab.id},
+              files: ['payload.js']
+            });
+          })
         } else {
           var goToSettings = confirm(
             'You need to grant file permissions to load a case file. Would you like to go to settings?\n\n\n\nIn settings, make sure "Allow access to file URLs" is on.'

--- a/extensionDirectory/package.json
+++ b/extensionDirectory/package.json
@@ -27,7 +27,8 @@
     "pretty-check": "npx prettier --check \"./**/*.{js,html,css}\"",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "node build.js",
-    "build:watch": "echo 'TODO: Setup watch building'"
+    "build:watch": "echo 'TODO: Setup watch building'",
+    "postbuild": "npm i --production --prefix=./build"
   },
   "keywords": [],
   "author": "",

--- a/extensionDirectory/static/filings.html
+++ b/extensionDirectory/static/filings.html
@@ -20,7 +20,7 @@
     />
 
     <!-- Vue -->
-    <script src="./node_modules/vue/dist/vue.js"></script>
+    <script src="./node_modules/vue/dist/vue.global.js"></script>
 
     <!-- Smooth-Scroll -->
     <script src="./node_modules/smooth-scroll/dist/smooth-scroll.polyfills.min.js"></script>

--- a/extensionDirectory/static/manifest.json
+++ b/extensionDirectory/static/manifest.json
@@ -3,10 +3,11 @@
   "version": "4.1.1",
   "description": "Co-counsel Edition - Expunge Harder. Expunge Smarter.",
   "permissions": [
-    "storage",
-    "declarativeContent",
     "activeTab",
-    "downloads"
+    "declarativeContent",
+    "downloads",
+    "scripting",
+    "storage"
   ],
   "background": {
     "service_worker": "background.js"

--- a/extensionDirectory/utils.js
+++ b/extensionDirectory/utils.js
@@ -1,0 +1,24 @@
+/**
+ * Replaces console.log() statements with a wrapper that prevents the extension from logging
+ * to the console unless it was installed by a developer. This will keep the console clean; a
+ * practice recommended for chrome extensions.
+ *
+ * @param {any} data Data to log to the console
+ * @todo find a way to make this reusuable, then delete the duplicate fn() in popup.js
+ */
+export function devLog(data) {
+  // see https://developer.chrome.com/extensions/management#method-getSelf
+  chrome.management.getSelf(function (self) {
+    if (self.installType == 'development') {
+      console.log(data);
+    }
+  });
+}
+
+export function getError() {
+  return 'TOOD: getError should work :('; // TODO: The code below explodes, so just no-op for now
+  // return new Error().stack
+  //   .split('\n')[1]
+  //   .split('filings.js')[1]
+  //   .replace(')', '')
+}


### PR DESCRIPTION
- **chrome.tabs.executeScript() has been deprecated.** Add the 'scripting' permission to manifest.json permissions. Consider making the following change to `popup.vue`:
```js
chrome.tabs.executeScript(null, { file: 'payload.js' });
```
to
```js
chrome.tabs.query({active: true, currentWindow: true}).then(([tab]) => {
        chrome.scripting.executeScript(
        {
          target: {tabId: tab.id},
          files: ['payload.js']
        });
      })
```


- **filings.html references a Vue script that needs to be modified.** Consider using `./node_modules/vue/dist/vue.global.js`.


- **chrome.extension.getURL is deprecated.** Use chrome.runtime.getURL instead.


- **Vue 3 no longer requires and deprecated Vue.set() for property reactivity.**

In popup.vue one may modify the following lines from Vue 2 `Vue.set()` method calls to just simply setting a property:

E.g. from
```js
this.$set(this.responses, noa.id + '-feeForm', false);
```
to
```js
this.responses[noa.id + '-feeForm'] = false;
```


- **`filings.html` requires several dependencies located in node_modules.** Consider adding an npm postbuild script to add production dependencies into the build directory.
```js
"postbuild": "npm i --production --prefix=./build"
```